### PR TITLE
passage_count query changes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -157,7 +157,7 @@ function formatData(data, passages) {
   });
 
   formattedData.results = newResults;
-  console.log('Formatting Data: size = ' + newResults.length);
+  // console.log('Formatting Data: size = ' + newResults.length);
   return formattedData;
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -152,6 +152,7 @@ function createServer() {
     }
 
     params.count = count;
+    params.passages_count = count;
     params.passages = returnPassages;
     if (! sort) {
       params.sort = utils.BY_HIGHEST_QUERY;
@@ -176,7 +177,7 @@ function createServer() {
     var searchQuery = req.params.searchQuery.replace(/\+/g, ' ');
     const qs = queryString.stringify({ 
       query: searchQuery,
-      count: 2000,
+      count: 1000,
       returnPassages: false,
       queryType: 'natural_language_query'
     });
@@ -230,7 +231,7 @@ function createServer() {
     console.log('Initial Search Query at start-up');
     const params = queryBuilder.search({ 
       natural_language_query: '',
-      count: 2000,
+      count: 1000,
       passages: false
     });
     return new Promise((resolve, reject) => {

--- a/server/query-builder.js
+++ b/server/query-builder.js
@@ -27,7 +27,6 @@ module.exports = {
     const params = Object.assign({
       environment_id: this.environment_id,
       collection_id: this.collection_id,
-      passages_count: '2000', // Set this to max. Only valid if doing 'passage' search
       aggregation:
         '[term(enriched_text.entities.text).term(enriched_text.sentiment.document.label),' +
         'term(enriched_text.categories.label).term(enriched_text.sentiment.document.label),' +

--- a/src/main.js
+++ b/src/main.js
@@ -347,7 +347,7 @@ class Main extends React.Component {
     const qs = queryString.stringify({
       query: trendQuery,
       filters: this.buildFilterString(),
-      count: (limitResults == true ? 100 : 2000)
+      count: (limitResults == true ? 100 : 1000)
     });
 
     // send request
@@ -427,7 +427,7 @@ class Main extends React.Component {
     const qs = queryString.stringify({
       query: searchQuery,
       filters: this.buildFilterString(),
-      count: (limitResults == true ? 100 : 2000),
+      count: (limitResults == true ? 100 : 1000),
       sort: sortOrder,
       returnPassages: returnPassages,
       queryType: (queryType === utils.QUERY_NATURAL_LANGUAGE ? 

--- a/test/query-builder.test.js
+++ b/test/query-builder.test.js
@@ -26,7 +26,6 @@ describe('Query builder returns params for discovery service', () => {
     expect(queryBuilder.search()).toEqual({
       environment_id: 'environment',
       collection_id: 'collection',
-      passages_count: '2000',
       aggregation: '[term(enriched_text.entities.text).term(enriched_text.sentiment.document.label),' +
       'term(enriched_text.categories.label).term(enriched_text.sentiment.document.label),' +
       'term(enriched_text.concepts.text).term(enriched_text.sentiment.document.label),' +
@@ -44,7 +43,6 @@ describe('Query builder returns params for discovery service', () => {
     })).toEqual({
       environment_id: 'environment',
       collection_id: 'collection',
-      passages_count: '2000',
       aggregation: 
         '[term(enriched_text.entities.text).term(enriched_text.sentiment.document.label),' +
         'term(enriched_text.categories.label).term(enriched_text.sentiment.document.label),' +


### PR DESCRIPTION
- set 'passage_count' to 1000 (default) or 100, if the user wishes to limit the results
- this syncs up with how 'count' is set in the query