### PR TITLE
add highlighting of key word(s) in text

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,9 @@
 
 // Variables and functions needed by both server and client code
 
+// needed to find tags in results text
+const parse5 = require('parse5');
+
 // how many items will we show per page
 const ITEMS_PER_PAGE = 7;
 
@@ -113,7 +116,9 @@ const parseData = data => ({
 
 /**
  * formatData - format search results into items we can process easier. This includes
- * only keeping fields we show in the UI, and only keep 'passages', if specified.
+ * 1) only keeping fields we show in the UI
+ * 2) highlight matching words in text
+ * 3) if showing 'passages', ignore all other results
  */
 function formatData(data, passages) {
   var formattedData = {};
@@ -129,26 +134,52 @@ function formatData(data, passages) {
       score: dataItem.result_metadata.score,
       sentimentScore: dataItem.enriched_text.sentiment.document.score,
       sentimentLabel: dataItem.enriched_text.sentiment.document.label,
-      hasPassage: false,
-      passageField: '',
-      passageScore: '0'
+      passage: {
+        showPassage: false,
+        field: '',
+        score: '0'
+      },
+      highlight: {
+        showHighlight: false
+      }
     };
 
     var addResult = true;
     if (passages.results) {
-      addResult = false;  // only add if associated passage is found
+      // see if this 'result' has a cooresponding 'passage' entry
+      // if so, save the details on how to highlight the 'passage'
+      // if not, ignore the 'result'
+      addResult = false;
       for (var i=0; i<passages.results.length; i++) {
         var res = passages.results[i];
         if (res.document_id === dataItem.id) {
-          newResult.hasPassage = true;
-          newResult.passageStart = res.start_offset;
-          newResult.passageEnd = res.end_offset;
-          newResult.passageField = res.field;
-          newResult.passageScore = res.passage_score;
+          newResult.passage.showPassage = true;
+          newResult.passage.startIdx = res.start_offset;
+          newResult.passage.endIdx = res.end_offset;
+          newResult.passage.field = res.field;
+          newResult.passage.score = res.passage_score;
           addResult = true;
           break;
         }
       }
+    } else {
+      // check if we have anything in the text to highlight
+      if (dataItem.highlight && dataItem.highlight.text) {
+        // start by getting highlight word(s) by parsing HTML.
+        // keyword will be within <em> tag.
+        const fragment = parse5.parseFragment('<!DOCTYPE html><html>' + 
+          dataItem.highlight.text + 
+          '</html>');
+        if (fragment.childNodes[1].childNodes[0].value) {
+          var highlightStr = fragment.childNodes[1].childNodes[0].value;
+          // now find that string in real 'text' field
+          newResult.highlight.startIdx = dataItem.text.indexOf(highlightStr);
+          if (newResult.highlight.startIdx >= 0) {
+            newResult.highlight.endIdx = newResult.highlight.startIdx + highlightStr.length;
+            newResult.highlight.showHighlight = true;
+          }
+        }
+      }      
     }
 
     if (addResult) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2156,8 +2156,7 @@
         "dom-serializer": "0.1.0",
         "entities": "1.1.1",
         "htmlparser2": "3.9.2",
-        "lodash": "4.17.4",
-        "parse5": "3.0.3"
+        "lodash": "4.17.4"
       }
     },
     "chokidar": {
@@ -7603,7 +7602,6 @@
         "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
         "pn": "1.0.0",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
@@ -10982,13 +10980,9 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.0.58"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
     },
     "parseurl": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "metrics-tracker-client": "*",
     "moment": "^2.19.4",
     "npm-check-updates": "^2.13.0",
+    "parse5": "^4.0.0",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.1",
     "react": "^15.5.0",

--- a/server/query-builder.js
+++ b/server/query-builder.js
@@ -27,6 +27,7 @@ module.exports = {
     const params = Object.assign({
       environment_id: this.environment_id,
       collection_id: this.collection_id,
+      highlight: true,
       aggregation:
         '[term(enriched_text.entities.text).term(enriched_text.sentiment.document.label),' +
         'term(enriched_text.categories.label).term(enriched_text.sentiment.document.label),' +

--- a/src/Matches/index.js
+++ b/src/Matches/index.js
@@ -99,22 +99,22 @@ Matches.propTypes = {
 
 // format title into 3 parts, so that we can set background color for passages
 const getTitle = (item, step) => {
-  var usePassage = item.hasPassage && item.passageField === 'title';
+  var usePassage = item.passage.showPassage && item.passage.field === 'title';
   if (step === 1) {
     if (usePassage) {
-      return item.title.substring(0,item.passageStart);
+      return item.title.substring(0,item.passage.startIdx);
     } else {
       return item.title ? item.title : 'No Title';
     }
   } else if (step === 2) {
     if (usePassage) {
-      return item.title.substring(item.passageStart, item.passageEnd);
+      return item.title.substring(item.passage.startIdx, item.passage.endIdx);
     } else {
       return '';
     }
   } else {
     if (usePassage) {
-      return item.title.substring(item.passageEnd);
+      return item.title.substring(item.passage.endIdx);
     } else {
       return '';
     }
@@ -122,23 +122,33 @@ const getTitle = (item, step) => {
 };
 
 // format text into 3 parts, so that we can set background color for passages
+// and highlighted words
 const getText = (item, step) => {
-  var usePassage = item.hasPassage && item.passageField === 'text';
+  var useHighlights = false;
+  if (item.passage.showPassage && item.passage.field === 'text') {
+    useHighlights = true;
+    var startIdx = item.passage.startIdx;
+    var endIdx = item.passage.endIdx;
+  } else if (item.highlight.showHighlight) {
+    useHighlights = true;
+    startIdx = item.highlight.startIdx;
+    endIdx = item.highlight.endIdx;
+  }
   if (step === 1) {
-    if (usePassage) {
-      return item.text.substring(0,item.passageStart);
+    if (useHighlights) {
+      return item.text.substring(0,startIdx);
     } else {
       return item.text ? item.text : 'No Description';
     }
   } else if (step === 2) {
-    if (usePassage) {
-      return item.text.substring(item.passageStart, item.passageEnd);
+    if (useHighlights) {
+      return item.text.substring(startIdx, endIdx);
     } else {
       return '';
     }
   } else {
-    if (usePassage) {
-      return item.text.substring(item.passageEnd);
+    if (useHighlights) {
+      return item.text.substring(endIdx);
     } else {
       return '';
     }

--- a/test/matches.test.js
+++ b/test/matches.test.js
@@ -27,7 +27,9 @@ var match = {
       'text': '<div className="description">I had a great time<span style={Object { "backgroundColor": "#ffffb3" }}></span></div>',
       'date': '2014-11-01',
       'sentimentLabel': 'positive',
-      'sentimentScore': 0.761482
+      'sentimentScore': 0.761482,
+      'passage': { 'showPassage': false },
+      'highlight': { 'showHighlight': false }
     }
   ]
 };

--- a/test/query-builder.test.js
+++ b/test/query-builder.test.js
@@ -26,6 +26,7 @@ describe('Query builder returns params for discovery service', () => {
     expect(queryBuilder.search()).toEqual({
       environment_id: 'environment',
       collection_id: 'collection',
+      highlight: true,
       aggregation: '[term(enriched_text.entities.text).term(enriched_text.sentiment.document.label),' +
       'term(enriched_text.categories.label).term(enriched_text.sentiment.document.label),' +
       'term(enriched_text.concepts.text).term(enriched_text.sentiment.document.label),' +
@@ -43,6 +44,7 @@ describe('Query builder returns params for discovery service', () => {
     })).toEqual({
       environment_id: 'environment',
       collection_id: 'collection',
+      highlight: true,
       aggregation: 
         '[term(enriched_text.entities.text).term(enriched_text.sentiment.document.label),' +
         'term(enriched_text.categories.label).term(enriched_text.sentiment.document.label),' +


### PR DESCRIPTION
- now use 'highlight:true' for all queries, which only means something if the user is searching on a string
- this now returns any keyword(s) matches it finds. If the match is in the text field, we figure out start and end indexes of the keywords in the text.
- we now use that info to highlight the word(s) in the UI