### PR TITLE
only highlight 'mentions' text if it matches a selected entity filter

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -222,7 +222,7 @@ function formatData(data, passages, queryFilter) {
       }
 
       // check if we have any entity 'mentions' returned by discovery.
-      // if so, also include them if they match one of the selected
+      // if so, only include them if they match one of the selected
       // filter strings.
       if (filterString.length > 1) {
         // we only care if we have some filter values

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,17 +118,48 @@ const parseData = data => ({
 });
 
 /**
+ * buildFilterStringForMentions - convert query filter string
+ * (format of 'enriched_text.entities.text::"<name>")
+ * and convert it to a string with the format '::<name>'.
+ */
+function buildFilterStringForMentions(queryFilter) {
+  var filterString = '';
+  var searchString = 'enriched_text.entities.text::"';
+  var searchStringLen = 'enriched_text.entities.text::"'.length;
+
+  if (typeof queryFilter !== 'undefined' && queryFilter.length > 0) {
+    var curIdx = 0;
+    var startIdx = 0;
+    var endIdx = 0;
+    while (startIdx >= 0 && endIdx >= 0) {
+      startIdx = queryFilter.indexOf(searchString, curIdx);
+      if (startIdx > -1) {
+        startIdx = startIdx + searchStringLen;
+        endIdx = queryFilter.indexOf('"', startIdx);
+        if (endIdx > -1) {
+          filterString = filterString + '::' + queryFilter.substr(startIdx, endIdx-startIdx);
+          curIdx = endIdx + 1;
+        }
+      }
+    }
+  }
+  return filterString;
+}
+
+/**
  * formatData - format search results into items we can process easier. This includes
  * 1) only keeping fields we show in the UI
  * 2) highlight matching words in text
  * 3) if showing 'passages', ignore all other results
  */
-function formatData(data, passages) {
+function formatData(data, passages, queryFilter) {
   var formattedData = {};
   var newResults = [];
 
+  var filterString = buildFilterStringForMentions(queryFilter);
+
   data.results.forEach(function(dataItem) {
-    // only keep the data we show
+    // only keep the data we show in the UI
     var newResult = {
       id: dataItem.id,
       title: dataItem.title,
@@ -146,6 +177,8 @@ function formatData(data, passages) {
     };
 
     var addResult = true;
+
+    // NOTE: only do passages or 'highlights', not both
     if (passages.results) {
       // see if this 'result' has a cooresponding 'passage' entry
       // if so, save the details on how to highlight the 'passage'
@@ -188,22 +221,33 @@ function formatData(data, passages) {
         }
       }
 
-      // check if we have any entity 'mentions' returned by discovery
-      dataItem.enriched_text.entities.forEach(function(entity) {
-        if (typeof entity.mentions !== 'undefined' && entity.mentions.length > 0) {
-          entity.mentions.forEach(function(mention) {
-            newResult.highlight.showHighlight = true;
-            newResult.highlight.field = 'text';
-            var insertIdx = getArrayIndex(newResult.highlight.indexes,
-              mention.location[0],
-              mention.location[1]);
-            if (insertIdx >= 0) {
-              newResult.highlight.indexes.splice(
-                insertIdx, 0, { startIdx: mention.location[0], endIdx: mention.location[1] });
-            }
-          });
-        }
-      });
+      // check if we have any entity 'mentions' returned by discovery.
+      // if so, also include them if they match one of the selected
+      // filter strings.
+      if (filterString.length > 1) {
+        // we only care if we have some filter values
+        dataItem.enriched_text.entities.forEach(function(entity) {
+          if (typeof entity.mentions !== 'undefined' && entity.mentions.length > 0) {
+            entity.mentions.forEach(function(mention) {
+              // get the text that will be highlighted
+              var highlightText = '::' +
+                dataItem.text.substr(mention.location[0], mention.location[1] - mention.location[0]);
+
+              // only highlight if it matches one of our filter values
+              if (filterString.indexOf(highlightText) >= 0) {
+                newResult.highlight.showHighlight = true;
+                newResult.highlight.field = 'text';
+                var insertIdx = getArrayIndex(newResult.highlight.indexes,
+                  mention.location[0]);
+                if (insertIdx >= 0) {
+                  newResult.highlight.indexes.splice(
+                    insertIdx, 0, { startIdx: mention.location[0], endIdx: mention.location[1] });
+                }
+              }
+            });
+          }
+        });
+      }
     }
 
     if (addResult) {

--- a/src/Matches/index.js
+++ b/src/Matches/index.js
@@ -86,7 +86,7 @@ Matches.propTypes = {
   matches: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
-// format title into 3 parts, so that we can set background color for passages
+// format title, setting backgroud color for all highlighted words
 const getTitle = (item) => {
   if (item.highlight.showHighlight && item.highlight.field === 'title') {
     var str = '<style>hilite {background:#ffffb3;}</style>';
@@ -103,8 +103,7 @@ const getTitle = (item) => {
   }
 };
 
-// format text into 3 parts, so that we can set background color for passages
-// and highlighted words
+// format text, setting background color for all highlighted words
 const getText = (item) => {
   if (item.highlight.showHighlight && item.highlight.field === 'text') {
     var str = '<style>hilite {background:#ffffb3;}</style>';

--- a/src/main.js
+++ b/src/main.js
@@ -442,11 +442,12 @@ class Main extends React.Component {
 
     scrollToMain();
     history.pushState({}, {}, `/${searchQuery.replace(/ /g, '+')}`);
+    const filterString = this.buildFilterStringForQuery();
 
     // build query string, with filters and optional params
     const qs = queryString.stringify({
       query: searchQuery,
-      filters: this.buildFilterString(),
+      filters: filterString,
       count: (limitResults == true ? 100 : 1000),
       sort: sortOrder,
       returnPassages: returnPassages,
@@ -474,7 +475,7 @@ class Main extends React.Component {
           // console.log(util.inspect(passages.results, false, null));
         }
 
-        data = utils.formatData(data, passages);
+        data = utils.formatData(data, passages, filterString);
         
         console.log('+++ DISCO RESULTS +++');
         // const util = require('util');
@@ -515,10 +516,10 @@ class Main extends React.Component {
   }
   
   /**
-   * buildFilterStringForType - build the filter string for
+   * buildFilterStringForFacet - build the filter string for
    * one set of filter objects.
    */
-  buildFilterStringForType(collection, keyName, firstOne) {
+  buildFilterStringForFacet(collection, keyName, firstOne) {
     var str = '';
     var firstValue = firstOne; 
     if (collection.size > 0) {
@@ -545,7 +546,7 @@ class Main extends React.Component {
    * buildFilterString - convert all selected filters into a string
    * to be added to the search query sent to the discovery service
    */
-  buildFilterString() {
+  buildFilterStringForQuery() {
     var { 
       selectedEntities, 
       selectedCategories, 
@@ -556,27 +557,27 @@ class Main extends React.Component {
     var filterString = '';
     
     // add any entities filters, if selected
-    var entitiesString = this.buildFilterStringForType(selectedEntities,
+    var entitiesString = this.buildFilterStringForFacet(selectedEntities,
       'enriched_text.entities.text::', true);
     filterString = filterString + entitiesString;
       
     // add any category filters, if selected
-    var categoryString = this.buildFilterStringForType(selectedCategories,
+    var categoryString = this.buildFilterStringForFacet(selectedCategories,
       'enriched_text.categories.label::', filterString === '');
     filterString = filterString + categoryString;
 
     // add any concept filters, if selected
-    var conceptString = this.buildFilterStringForType(selectedConcepts,
+    var conceptString = this.buildFilterStringForFacet(selectedConcepts,
       'enriched_text.concepts.text::', filterString === '');
     filterString = filterString + conceptString;
 
     // add any keyword filters, if selected
-    var keywordString = this.buildFilterStringForType(selectedKeywords,
+    var keywordString = this.buildFilterStringForFacet(selectedKeywords,
       'enriched_text.keywords.text::', filterString === '');
     filterString = filterString + keywordString;
 
     // add any entities type filters, if selected
-    var entityTypesString = this.buildFilterStringForType(selectedEntityTypes,
+    var entityTypesString = this.buildFilterStringForFacet(selectedEntityTypes,
       'enriched_text.entities.type::', filterString === '');
     filterString = filterString + entityTypesString;
 
@@ -608,15 +609,19 @@ class Main extends React.Component {
    */
   getMatches() {
     const { data, currentPage } = this.state;
+
     if (!data) {
       return null;
     }
 
+    // get one page of matches
     var page = parseInt(currentPage);
     var startIdx = (page - 1) * utils.ITEMS_PER_PAGE;
+    var pageOfMatches = data.results.slice(startIdx,startIdx+utils.ITEMS_PER_PAGE);
+
     return (
       <Matches 
-        matches={data.results.slice(startIdx,startIdx+utils.ITEMS_PER_PAGE)}
+        matches={ pageOfMatches }
       />
     );
   }


### PR DESCRIPTION
2 problems:

1) When discovery returns data, it includes includes a list of the top 'entities' it has extracted from the data. Discovery also returns a lists of 'mentions' objects that point to the start and end index where each of these 'entities' can be found in the text. We used this info to highlight the words within the text in the UI. This resulted in way too many words being highlighted.

2) If the user selects one of the 'entity' words listed in the entities filter, this would result in a new query being sent to discovery, and a new set of results would be returned. Since we highlight all of the 'entities' in the text, it is not obvious what effect the selecting of the 'entity' filter had on the results.

Solution - now we only highlight text if the text matches the 'entity' selected by the user. This results in a lot fewer words being highlighted in the text, and it will be obvious when the user selects any values in the 'entities' filter.