### PR TITLE
use original filter string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,45 +118,14 @@ const parseData = data => ({
 });
 
 /**
- * buildFilterStringForMentions - convert query filter string
- * (format of 'enriched_text.entities.text::"<name>")
- * and convert it to a string with the format '::<name>'.
- */
-function buildFilterStringForMentions(queryFilter) {
-  var filterString = '';
-  var searchString = 'enriched_text.entities.text::"';
-  var searchStringLen = 'enriched_text.entities.text::"'.length;
-
-  if (typeof queryFilter !== 'undefined' && queryFilter.length > 0) {
-    var curIdx = 0;
-    var startIdx = 0;
-    var endIdx = 0;
-    while (startIdx >= 0 && endIdx >= 0) {
-      startIdx = queryFilter.indexOf(searchString, curIdx);
-      if (startIdx > -1) {
-        startIdx = startIdx + searchStringLen;
-        endIdx = queryFilter.indexOf('"', startIdx);
-        if (endIdx > -1) {
-          filterString = filterString + '::' + queryFilter.substr(startIdx, endIdx-startIdx);
-          curIdx = endIdx + 1;
-        }
-      }
-    }
-  }
-  return filterString;
-}
-
-/**
  * formatData - format search results into items we can process easier. This includes
  * 1) only keeping fields we show in the UI
  * 2) highlight matching words in text
  * 3) if showing 'passages', ignore all other results
  */
-function formatData(data, passages, queryFilter) {
+function formatData(data, passages, filterString) {
   var formattedData = {};
   var newResults = [];
-
-  var filterString = buildFilterStringForMentions(queryFilter);
 
   data.results.forEach(function(dataItem) {
     // only keep the data we show in the UI
@@ -224,14 +193,16 @@ function formatData(data, passages, queryFilter) {
       // check if we have any entity 'mentions' returned by discovery.
       // if so, only include them if they match one of the selected
       // filter strings.
-      if (filterString.length > 1) {
+      if (typeof filterString !== 'undefined' && filterString.length > 1) {
         // we only care if we have some filter values
         dataItem.enriched_text.entities.forEach(function(entity) {
           if (typeof entity.mentions !== 'undefined' && entity.mentions.length > 0) {
             entity.mentions.forEach(function(mention) {
-              // get the text that will be highlighted
-              var highlightText = '::' +
-                dataItem.text.substr(mention.location[0], mention.location[1] - mention.location[0]);
+              // get the text that will be highlighted and put it in the
+              // same format as the filters passed in the query
+              // string sent to discovery
+              var highlightText = 'enriched_text.entities.text::"' +
+                dataItem.text.substr(mention.location[0], mention.location[1] - mention.location[0]) + '"';
 
               // only highlight if it matches one of our filter values
               if (filterString.indexOf(highlightText) >= 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -364,7 +364,7 @@ class Main extends React.Component {
 
     const qs = queryString.stringify({
       query: trendQuery,
-      filters: this.buildFilterString(),
+      filters: this.buildFilterStringForQuery(),
       count: (limitResults == true ? 100 : 1000)
     });
 
@@ -543,7 +543,7 @@ class Main extends React.Component {
   }
 
   /**
-   * buildFilterString - convert all selected filters into a string
+   * buildFilterStringForQuery - convert all selected filters into a string
    * to be added to the search query sent to the discovery service
    */
   buildFilterStringForQuery() {


### PR DESCRIPTION
- use original filter string sent to disco. No need to create another version of it just for purpose of search.
- fixed bug introduced in previous PR. New function name was not set in trending graph logic. 