### PR TITLE
highlight entity type matches

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ const ITEMS_PER_PAGE = 7;
 const QUERY_NATURAL_LANGUAGE = 0;
 const QUERY_DISCO_LANGUAGE = 1;
 
-// the index of the fillter item in the aggrgation data returned 
+// the index of the filter item in the aggregation data returned 
 // from the discovery query
 const ENTITY_DATA_INDEX      = 0;
 const CATEGORY_DATA_INDEX    = 1;
@@ -88,7 +88,7 @@ sortKeys.forEach(function(item) {
 });  
 
 /**
- * objectWithoutProperties - clear out unneded properties from object.
+ * objectWithoutProperties - clear out unneeded properties from object.
  * object: object to scan
  * properties: items in object to remove
  */
@@ -191,10 +191,13 @@ function formatData(data, passages, filterString) {
       }
 
       // check if we have any entity 'mentions' returned by discovery.
-      // if so, only include them if they match one of the selected
-      // filter strings.
+      // There can be 2 types of matches:
+      // 1 - user selected an 'entity' filter string, and that string appears in
+      //     this data item. Ex: filter on 'Bob', and 'Bob' is in text.
+      // 2 - user selected an 'entity.type' filter string, and a match of that type
+      //     appears in the data item. Ex: filter on type 'Sport' and 'golf' is found.
       if (typeof filterString !== 'undefined' && filterString.length > 1) {
-        // we only care if we have some filter values
+        // we only care if we have a match on our filter values
         dataItem.enriched_text.entities.forEach(function(entity) {
           if (typeof entity.mentions !== 'undefined' && entity.mentions.length > 0) {
             entity.mentions.forEach(function(mention) {
@@ -204,8 +207,10 @@ function formatData(data, passages, filterString) {
               var highlightText = 'enriched_text.entities.text::"' +
                 dataItem.text.substr(mention.location[0], mention.location[1] - mention.location[0]) + '"';
 
-              // only highlight if it matches one of our filter values
-              if (filterString.indexOf(highlightText) >= 0) {
+              // check if we have a direct match to our entity filter
+              // or if we have a direct match to our entity.type filter
+              if ((filterString.indexOf(highlightText) >= 0) ||
+                  (filterString.indexOf(entity.type) >= 0)) {
                 newResult.highlight.showHighlight = true;
                 newResult.highlight.field = 'text';
                 var insertIdx = getArrayIndex(newResult.highlight.indexes,

--- a/src/FilterBase/FilterItem/index.js
+++ b/src/FilterBase/FilterItem/index.js
@@ -25,11 +25,6 @@ import { Checkbox } from 'semantic-ui-react';
 class FilterItem extends React.Component {
   constructor(...props) {
     super(...props);
-
-    // const { isChecked } = this.props;
-    // this.state = {
-    //   isChecked: isChecked || false
-    // };
   }
 
   /**
@@ -38,13 +33,6 @@ class FilterItem extends React.Component {
    */
   toggleCheckboxChange() {
     const { handleCheckboxChange, label } = this.props;
-    // this.setState(({ isChecked }) => (
-    //   {
-    //     isChecked: !isChecked
-    //   }
-    // ));
-
-    // const { isChecked } = this.state;
     // inform parent of our state change
     handleCheckboxChange(label);
   }


### PR DESCRIPTION
expand highlighting of text when match is found that relates to entity.type filter selected by user. For example, if they filter on entity.type = 'Sport', we will highlight matches in text such as 'golf' and 'baseball'.