### PR TITLE
Remove deprecated metrics-tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-discovery-ui.svg?branch=master)](https://travis-ci.org/IBM/watson-discovery-ui)
-![Bluemix Deployments](https://metrics-tracker.mybluemix.net/stats/1d5f6ef7fb5364be97be249346b673c0/badge.svg)
 
 # Develop a fully featured web app built on the Watson Discovery Service
 
@@ -65,8 +64,8 @@ Use the ``Deploy to IBM Cloud`` button **OR** create the services and run locall
 
 ## Deploy to IBM Cloud
 
-[![Deploy to Bluemix](https://metrics-tracker.mybluemix.net/stats/1d5f6ef7fb5364be97be249346b673c0/button.svg)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-discovery-ui.git)
-
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-discovery-ui.git)
+ 
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy``.
 
 2. In Toolchains, click on Delivery Pipeline to watch while the app is deployed. Once deployed, the app can be viewed by clicking 'View app'.
@@ -169,27 +168,6 @@ be usable on restart. If you used `Deploy to IBM Cloud` the restart should be au
 * No keywords appear in the app
 
   > This can be due to not having a proper configuration file assigned to your data collection. See [Step 3](#3-load-the-discovery-files) above.
-
-# Privacy Notice
-
-If using the `Deploy to IBM Cloud` button some metrics are tracked, the following information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-tracker-service) service on each deployment:
-
-* Node.js package version
-* Node.js repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`)
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-
-This data is collected from the `package.json` file in the sample application and the ``VCAP_APPLICATION`` and ``VCAP_SERVICES`` environment variables in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
-
-## Disabling Deployment Tracking
-
-To disable tracking, simply remove `require("metrics-tracker-client").track();` from the ``index.js`` file in the ``server`` directory.
 
 # Links
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3270,15 +3270,6 @@
         "lodash.get": "4.4.2"
       }
     },
-    "cwd": {
-      "version": "0.10.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cwd/-/cwd-0.10.0.tgz",
-      "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
-      "requires": {
-        "find-pkg": "0.1.2",
-        "fs-exists-sync": "0.1.0"
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/dashdash/-/dashdash-1.14.1.tgz",
@@ -4441,14 +4432,6 @@
         "fill-range": "2.2.3"
       }
     },
-    "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
     "expect": {
       "version": "22.3.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/expect/-/expect-22.3.0.tgz",
@@ -4791,23 +4774,6 @@
         }
       }
     },
-    "find-file-up": {
-      "version": "0.1.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/find-file-up/-/find-file-up-0.1.3.tgz",
-      "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
-      "requires": {
-        "fs-exists-sync": "0.1.0",
-        "resolve-dir": "0.1.1"
-      }
-    },
-    "find-pkg": {
-      "version": "0.1.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/find-pkg/-/find-pkg-0.1.2.tgz",
-      "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
-      "requires": {
-        "find-file-up": "0.1.3"
-      }
-    },
     "find-replace": {
       "version": "1.0.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/find-replace/-/find-replace-1.0.3.tgz",
@@ -4923,11 +4889,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs-write-stream-atomic": {
       "version": "1.0.8",
@@ -5849,26 +5810,6 @@
         "ini": "1.3.5"
       }
     },
-    "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
-    },
-    "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "0.2.0",
-        "which": "1.3.0"
-      }
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/globals/-/globals-9.18.0.tgz",
@@ -6268,14 +6209,6 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
-      }
-    },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "requires": {
-        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -7044,11 +6977,6 @@
       "version": "0.2.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
     },
     "isarray": {
       "version": "0.0.1",
@@ -9139,32 +9067,6 @@
       "version": "1.1.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "metrics-tracker-client": {
-      "version": "0.2.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/metrics-tracker-client/-/metrics-tracker-client-0.2.3.tgz",
-      "integrity": "sha1-aFvaFeNTzTdnokzTOTbE2dBaNJg=",
-      "requires": {
-        "cwd": "0.10.0",
-        "js-yaml": "3.10.0",
-        "restler": "3.4.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
-          "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.0"
-          }
-        }
-      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -12531,11 +12433,6 @@
         "error-ex": "1.3.1"
       }
     },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/parse5/-/parse5-4.0.0.tgz",
@@ -13611,15 +13508,6 @@
         }
       }
     },
-    "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
-      }
-    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -13631,29 +13519,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
-    },
-    "restler": {
-      "version": "3.4.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/restler/-/restler-3.4.0.tgz",
-      "integrity": "sha1-dB7As9FrlJ/uooE9DDxoUp6IjZs=",
-      "requires": {
-        "iconv-lite": "0.2.11",
-        "qs": "1.2.0",
-        "xml2js": "0.4.0",
-        "yaml": "0.2.3"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
-        },
-        "qs": {
-          "version": "1.2.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/qs/-/qs-1.2.0.tgz",
-          "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
-        }
-      }
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -17049,22 +16914,6 @@
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
-    "xml2js": {
-      "version": "0.4.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/xml2js/-/xml2js-0.4.0.tgz",
-      "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
-      "requires": {
-        "sax": "0.5.8",
-        "xmlbuilder": "9.0.1"
-      },
-      "dependencies": {
-        "sax": {
-          "version": "0.5.8",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/sax/-/sax-0.5.8.tgz",
-          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
-        }
-      }
-    },
     "xmlbuilder": {
       "version": "9.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/xmlbuilder/-/xmlbuilder-9.0.1.tgz",
@@ -17099,11 +16948,6 @@
       "version": "2.1.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yaml": {
-      "version": "0.2.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/yaml/-/yaml-0.2.3.tgz",
-      "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc="
     },
     "yargs": {
       "version": "3.29.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "express-react-views": "^0.10.2",
     "g": "^2.0.1",
     "help": "^3.0.2",
-    "metrics-tracker-client": "*",
     "moment": "^2.19.4",
     "npm-check-updates": "^2.13.0",
     "parse5": "^4.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -34,8 +34,6 @@ const utils = require('../lib/utils');
  * service, and setting up route methods to handle client requests.
  */
 
-require('metrics-tracker-client').track();
-
 var environment_id;
 var collection_id;
 const DEFAULT_NAME = 'airbnb-austin-data';

--- a/test/__snapshots__/searchField.test.js.snap
+++ b/test/__snapshots__/searchField.test.js.snap
@@ -45,7 +45,9 @@ exports[`renders correctly 1`] = `
         <input
           checked={false}
           className="hidden"
+          id={undefined}
           name={undefined}
+          onClick={[Function]}
           readOnly={true}
           tabIndex={0}
           type="checkbox"
@@ -70,7 +72,9 @@ exports[`renders correctly 1`] = `
         <input
           checked={false}
           className="hidden"
+          id={undefined}
           name={undefined}
+          onClick={[Function]}
           readOnly={true}
           tabIndex={0}
           type="checkbox"
@@ -95,7 +99,9 @@ exports[`renders correctly 1`] = `
         <input
           checked={true}
           className="hidden"
+          id={undefined}
           name={undefined}
+          onClick={[Function]}
           readOnly={true}
           tabIndex={0}
           type="checkbox"


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
i.e. require('metrics-tracker-client').track();
package.json for metrics-tracker
package-lock.json stuff

Change D2B to:
https://bluemix.net/deploy/button.png