### PR TITLE
remove random route for deployment

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,6 @@ applications:
   buildpack: sdk-for-nodejs
   memory: 512M
   instances: 1
-  random-route: true
+  random-route: false
   services:
   - wdui-discovery-service


### PR DESCRIPTION
random route could potentially make the URL too long
Closes: #125 
