### PR TITLE
allow for iam_apikey

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,18 +127,20 @@ Edit the `.env` file with the necessary settings.
 #### `env.sample:`
 
 ```
-# Replace the credentials here with your own.
-# Rename this file to .env before starting the app.
+# Copy this file to .env and replace the credentials with
+# your own before starting the app.
 
 # Watson Discovery
-DISCOVERY_USERNAME=<add_discovery_username>
-DISCOVERY_PASSWORD=<add_discovery_password>
-DISCOVERY_ENVIRONMENT_ID=<add_discovery_environment>
-DISCOVERY_COLLECTION_ID=<add_discovery_collection>
+DISCOVERY_URL=<add_discovery_url>
+DISCOVERY_ENVIRONMENT_ID=<add_discovery_environment_id>
+DISCOVERY_COLLECTION_ID=<add_discovery_collection_id>
+## Un-comment and use either username+password or IAM apikey.
+# DISCOVERY_IAM_APIKEY=<add_discovery_iam_apikey>
+# DISCOVERY_USERNAME=<add_discovery_username>
+# DISCOVERY_PASSWORD=<add_discovery_password>
 
 # Run locally on a non-default port (default is 3000)
 # PORT=3000
-
 ```
 
 ### 5. Run the application

--- a/env.sample
+++ b/env.sample
@@ -1,11 +1,14 @@
-# Replace the credentials here with your own.
-# Rename this file to .env before starting the app.
+# Copy this file to .env and replace the credentials with
+# your own before starting the app.
 
 # Watson Discovery
-DISCOVERY_USERNAME=<add_discovery_username>
-DISCOVERY_PASSWORD=<add_discovery_password>
+DISCOVERY_URL=<add_discovery_url>
 DISCOVERY_ENVIRONMENT_ID=<add_discovery_environment_id>
 DISCOVERY_COLLECTION_ID=<add_discovery_collection_id>
+## Un-comment and use either username+password or IAM apikey.
+# DISCOVERY_IAM_APIKEY=<add_discovery_iam_apikey>
+# DISCOVERY_USERNAME=<add_discovery_username>
+# DISCOVERY_PASSWORD=<add_discovery_password>
 
 # Run locally on a non-default port (default is 3000)
 # PORT=3000

--- a/lib/watson-discovery-setup.js
+++ b/lib/watson-discovery-setup.js
@@ -40,7 +40,7 @@ function WatsonDiscoverySetup(discoveryClient) {
  */
 WatsonDiscoverySetup.prototype.findDiscoveryConfig = function(params) {
   return new Promise((resolve, reject) => {
-    this.discoveryClient.getConfigurations(params, (err, data) => {
+    this.discoveryClient.listConfigurations(params, (err, data) => {
       if (err) {
         console.error(err);
         return reject(new Error('Failed to get Discovery configurations.'));
@@ -149,7 +149,7 @@ WatsonDiscoverySetup.prototype.createDiscoveryConfig = function(params) {
  */
 WatsonDiscoverySetup.prototype.findDiscoveryEnvironment = function(params) {
   return new Promise((resolve, reject) => {
-    this.discoveryClient.getEnvironments(params, (err, data) => {
+    this.discoveryClient.listEnvironments(params, (err, data) => {
       if (err) {
         console.error(err);
         return reject(new Error('Failed to get Discovery environments.'));
@@ -209,7 +209,7 @@ WatsonDiscoverySetup.prototype.findDiscoveryEnvironment = function(params) {
 WatsonDiscoverySetup.prototype.findDiscoveryCollection = function(params) {
   console.log('findDiscoveryCollection');
   return new Promise((resolve, reject) => {
-    this.discoveryClient.getCollections(params, (err, data) => {
+    this.discoveryClient.listCollections(params, (err, data) => {
       if (err) {
         console.error(err);
         return reject(new Error('Failed to get Discovery collections.'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -396,44 +396,325 @@
         "envify": "^3.4.1"
       }
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
+      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
+    },
+    "@octokit/rest": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.4.tgz",
+      "integrity": "sha512-v3CS1qW4IjriMvGgm4lDnYFBJlkwvzIbTxiipOcwVP8xeK8ih2pJofRhk7enmLngTtNEa+sIApJNkXxyyDKqLg==",
+      "requires": {
+        "before-after-hook": "^1.1.0",
+        "btoa-lite": "^1.0.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.0",
+        "lodash": "^4.17.4",
+        "node-fetch": "^2.1.1",
+        "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+          "requires": {
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+        }
+      }
+    },
+    "@semantic-release/commit-analyzer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-5.1.0.tgz",
+      "integrity": "sha512-YS4b2DkazI0/k/DyfjaOPCgv9epvVIle2eZv0hfU/wpVwJFTlIFHcLvylJ7m73aM8e4+F1XJwsy3XZ1RxKqi7Q==",
+      "requires": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^3.1.0",
+        "import-from": "^2.1.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "@semantic-release/error": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
+    },
+    "@semantic-release/github": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-4.4.2.tgz",
+      "integrity": "sha512-/b+KTFpLvlfAjuNhvPFIDWMwN0JjkjQVANX9H79YVPRvO7Z31GiHd/8da0ABRO6wbDSOPZHWd2bP4fl2a9PmRw==",
+      "requires": {
+        "@octokit/rest": "^15.2.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^1.0.0",
+        "bottleneck": "^2.0.1",
+        "debug": "^3.1.0",
+        "fs-extra": "^7.0.0",
+        "globby": "^8.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "issue-parser": "^2.2.0",
+        "lodash": "^4.17.4",
+        "mime": "^2.0.3",
+        "p-filter": "^1.0.0",
+        "p-retry": "^2.0.0",
+        "parse-github-url": "^1.0.1",
+        "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globby": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+          "requires": {
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "url-join": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
+        }
+      }
+    },
+    "@semantic-release/npm": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-3.4.1.tgz",
+      "integrity": "sha512-YhJpufyrEWWR3u57ARcUu+dlGwiLlw5qfy9aCDG6KJuCnSwv04Eb0B9bLxwGTUssxwQF/cgFPJONJtl/9v7JQQ==",
+      "requires": {
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^1.0.0",
+        "detect-indent": "^5.0.0",
+        "detect-newline": "^2.1.0",
+        "execa": "^0.10.0",
+        "fs-extra": "^7.0.0",
+        "lodash": "^4.17.4",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^3.0.0",
+        "parse-json": "^4.0.0",
+        "read-pkg": "^4.0.0",
+        "registry-auth-token": "^3.3.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+          "requires": {
+            "normalize-package-data": "^2.3.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@semantic-release/release-notes-generator": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.1.1.tgz",
+      "integrity": "sha512-9OF/47Am/HHGbS4PtSkyBk+O1JIaQfREfg1tPnkSpE2GiOjl5d/AD/ug9y15E1FTDk3/mmhhrq3d/dCNRpgnNw==",
+      "requires": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^3.1.0",
+        "get-stream": "^3.0.0",
+        "git-url-parse": "^10.0.1",
+        "import-from": "^2.1.0",
+        "into-stream": "^3.1.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "git-url-parse": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-10.0.1.tgz",
+          "integrity": "sha512-Tq2u8UPXc/FawC/dO8bvh8jcck0Lkor5OhuZvmVSeyJGRucDBfw9y2zy/GNCx28lMYh1N12IzPwDexjUNFyAeg==",
+          "requires": {
+            "git-up": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "@types/caseless": {
       "version": "0.12.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha1-l5TGnIOF0BkqzEcaVA0fjg0WIYo="
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
     },
     "@types/csv-stringify": {
       "version": "1.4.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/csv-stringify/-/csv-stringify-1.4.2.tgz",
-      "integrity": "sha1-OnHG9QiuQ0M54jBNNrsAF35lnZU=",
+      "resolved": "https://registry.npmjs.org/@types/csv-stringify/-/csv-stringify-1.4.2.tgz",
+      "integrity": "sha512-OxBpngVW09fD5S90Fi2ihWJa9gWk/cYSeZ05T5PiElOJw4OjKq9bXyVEkEPpHS/1Vr/gKzAgv7okuvHLpb5CSA==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/extend": {
       "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-0mnlrxRjzWNEJyq9gUyKgzuRTQc="
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha512-Eo8NQCbgjlMPQarlFAE3vpyCvFda4dg1Ob5ZJb6BJI9x4NAZVWowyMNB8GJJDgDI4lr2oqiQvXlPB0Fn1NoXnQ=="
     },
     "@types/file-type": {
       "version": "5.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/file-type/-/file-type-5.2.1.tgz",
-      "integrity": "sha1-569J4IGHtrdZhQnF5BZmnSX6NGE=",
+      "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.1.tgz",
+      "integrity": "sha512-Im0cJaIPJbbpuW91OrjXnqWPZCJK/tcFy2cFX+1qjG1gubgVZPPO9OVsTVAjotN4I1E6FAV0eIqt+rR8Y1c3iA==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/form-data": {
       "version": "2.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "requires": {
         "@types/node": "*"
       }
@@ -444,9 +725,9 @@
       "integrity": "sha1-OhKc2nxOXfJAlwJiaJLLS5ZUbdU="
     },
     "@types/request": {
-      "version": "2.47.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/request/-/request-2.47.0.tgz",
-      "integrity": "sha1-dqZmzuTLhdz/6mzUZFInkm2eEU4=",
+      "version": "2.47.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
+      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -455,9 +736,9 @@
       }
     },
     "@types/tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/@types/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-4NSB2LsoKtioyeEAzrcsmV+15wk="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
     },
     "@xmpp/jid": {
       "version": "0.0.2",
@@ -578,6 +859,15 @@
       "integrity": "sha1-mDi1wzkrliutAx5qTF4QJKvsRc4=",
       "requires": {
         "es6-promisify": "^5.0.0"
+      }
+    },
+    "aggregate-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
+      "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+      "requires": {
+        "clean-stack": "^1.0.0",
+        "indent-string": "^3.0.0"
       }
     },
     "ajv": {
@@ -722,11 +1012,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
-    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/anymatch/-/anymatch-1.3.2.tgz",
@@ -745,11 +1030,6 @@
         "default-require-extensions": "^1.0.0"
       }
     },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/argparse/-/argparse-1.0.10.tgz",
@@ -764,6 +1044,11 @@
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         }
       }
+    },
+    "argv-formatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk="
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -781,8 +1066,7 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-back": {
       "version": "2.0.0",
@@ -803,10 +1087,20 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
     },
     "array-includes": {
       "version": "3.0.3",
@@ -842,7 +1136,6 @@
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
       "requires": {
         "array-uniq": "^1.0.1"
       }
@@ -850,8 +1143,7 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -861,8 +1153,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -897,11 +1188,15 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
       "version": "0.9.6",
@@ -955,13 +1250,7 @@
     "atob": {
       "version": "2.0.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
-      "dev": true
-    },
-    "attempt-x": {
-      "version": "1.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/attempt-x/-/attempt-x-1.1.1.tgz",
-      "integrity": "sha1-+6ZOls4Dw+C9kskmIgYcTfOHy3Y="
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1744,7 +2033,6 @@
       "version": "0.11.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
-      "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -1758,8 +2046,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -1786,6 +2073,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1842,22 +2134,6 @@
           "version": "4.2.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
-        }
-      }
-    },
-    "bops": {
-      "version": "0.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/bops/-/bops-0.1.1.tgz",
-      "integrity": "sha1-Bi4CqNqoAfoQ8uXb5nQM/4Af4X4=",
-      "requires": {
-        "base64-js": "0.0.2",
-        "to-utf8": "0.0.1"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "0.0.2",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/base64-js/-/base64-js-0.0.2.tgz",
-          "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
         }
       }
     },
@@ -1943,25 +2219,10 @@
         }
       }
     },
-    "boxen": {
-      "version": "0.3.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/boxen/-/boxen-0.3.1.tgz",
-      "integrity": "sha1-p9iYJDrmIvertrtgTXQKdsalRhs=",
-      "requires": {
-        "chalk": "^1.1.1",
-        "filled-array": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "repeating": "^2.0.0",
-        "string-width": "^1.0.1",
-        "widest-line": "^1.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        }
-      }
+    "bottleneck": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.6.0.tgz",
+      "integrity": "sha512-3fgu36UohvqOzv4aYPFyUR39LckOcA5cM4Yxija/V9Effd7a/22tFtZga89t3rSNtqEqo0bMT8IhCFztD7d/8A=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2046,6 +2307,11 @@
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "browserify": {
       "version": "11.2.0",
@@ -2285,6 +2551,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
     "buffer": {
       "version": "3.6.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/buffer/-/buffer-3.6.0.tgz",
@@ -2308,12 +2579,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "0.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/buffer-from/-/buffer-from-0.1.1.tgz",
-      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "requires": {
-        "is-array-buffer-x": "^1.0.13"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2344,7 +2612,6 @@
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
-      "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -2360,20 +2627,50 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
-    "cached-constructors-x": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cached-constructors-x/-/cached-constructors-x-1.0.0.tgz",
-      "integrity": "sha1-xCHjiSpLb3eUQ0vc/9EpmzMMGBs="
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        }
+      }
     },
     "cached-path-relative": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
       "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -2395,6 +2692,23 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30000815",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000815.tgz",
@@ -2405,6 +2719,22 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
     },
+    "cardinal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
+      },
+      "dependencies": {
+        "ansicolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+          "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+        }
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/caseless/-/caseless-0.12.0.tgz",
@@ -2414,6 +2744,7 @@
       "version": "0.1.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "optional": true,
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
@@ -2434,6 +2765,19 @@
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         }
+      }
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -2492,6 +2836,11 @@
         "color-name": "^1.0.0"
       }
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -2549,7 +2898,7 @@
     },
     "cint": {
       "version": "8.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cint/-/cint-8.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
       "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI="
     },
     "cipher-base": {
@@ -2594,7 +2943,6 @@
       "version": "0.3.6",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
-      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -2606,7 +2954,6 @@
           "version": "0.2.5",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -2615,7 +2962,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -2624,7 +2970,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -2635,7 +2980,6 @@
           "version": "0.1.4",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -2644,7 +2988,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -2655,7 +2998,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -2665,14 +3007,12 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-          "dev": true
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
@@ -2680,6 +3020,11 @@
       "version": "2.2.5",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/classnames/-/classnames-2.2.5.tgz",
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
+    "clean-stack": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "cli-boxes": {
       "version": "1.0.0",
@@ -2707,94 +3052,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
     },
-    "clite": {
-      "version": "0.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/clite/-/clite-0.3.0.tgz",
-      "integrity": "sha1-5/y8jMW9Pn+LhO1I2xLpR0zHNEE=",
-      "requires": {
-        "abbrev": "^1.0.7",
-        "debug": "^2.2.0",
-        "es6-promise": "^3.1.2",
-        "lodash.defaults": "^4.0.1",
-        "lodash.defaultsdeep": "^4.3.1",
-        "lodash.mergewith": "^4.3.1",
-        "then-fs": "^2.0.0",
-        "update-notifier": "^0.6.0",
-        "yargs": "^4.3.2"
-      },
-      "dependencies": {
-        "configstore": {
-          "version": "2.1.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/configstore/-/configstore-2.1.0.tgz",
-          "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-          "requires": {
-            "dot-prop": "^3.0.0",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.1",
-            "os-tmpdir": "^1.0.0",
-            "osenv": "^0.1.0",
-            "uuid": "^2.0.1",
-            "write-file-atomic": "^1.1.2",
-            "xdg-basedir": "^2.0.0"
-          }
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "update-notifier": {
-          "version": "0.6.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/update-notifier/-/update-notifier-0.6.3.tgz",
-          "integrity": "sha1-d23sjaoT6WKjQeih2YNUMGtnrgg=",
-          "requires": {
-            "boxen": "^0.3.1",
-            "chalk": "^1.0.0",
-            "configstore": "^2.0.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^2.0.0",
-            "semver-diff": "^2.0.0"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-        },
-        "yargs": {
-          "version": "4.8.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
-          }
-        }
-      }
-    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cliui/-/cliui-3.2.0.tgz",
@@ -2810,25 +3067,12 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/clone/-/clone-2.1.1.tgz",
       "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
-    "clone-deep": {
-      "version": "0.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/clone-deep/-/clone-deep-0.3.0.tgz",
-      "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
-        "for-own": "^1.0.0",
-        "is-plain-object": "^2.0.1",
-        "kind-of": "^3.2.2",
-        "shallow-clone": "^0.1.2"
-      },
-      "dependencies": {
-        "for-own": {
-          "version": "1.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/for-own/-/for-own-1.0.0.tgz",
-          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        }
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -2845,7 +3089,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -2921,11 +3164,19 @@
         "recast": "^0.11.17"
       }
     },
+    "compare-func": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "requires": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
+      }
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "computed-style": {
       "version": "0.1.4",
@@ -3001,33 +3252,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "configstore": {
-      "version": "1.4.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/configstore/-/configstore-1.4.0.tgz",
-      "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.1",
-        "os-tmpdir": "^1.0.0",
-        "osenv": "^0.1.0",
-        "uuid": "^2.0.1",
-        "write-file-atomic": "^1.1.2",
-        "xdg-basedir": "^2.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
-      }
-    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -3063,6 +3287,139 @@
       "integrity": "sha1-yqvoBiPmNjiyUC/Ux/Ev9M4jUuc=",
       "dev": true
     },
+    "conventional-changelog-angular": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.0.tgz",
+      "integrity": "sha512-R75W1aOI9FNhnxLu9wz+jlGM+VSZLZvV10LBBLyx73S12RatSI5s3fUwlstKNybWolXZgBb6qvdkCfrRVqddZQ==",
+      "requires": {
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-writer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.0.tgz",
+      "integrity": "sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==",
+      "requires": {
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^2.0.0",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "requires": {
+            "through": "2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "conventional-commits-filter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.0.tgz",
+      "integrity": "sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==",
+      "requires": {
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
+      }
+    },
+    "conventional-commits-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.0.tgz",
+      "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
+      "requires": {
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
     "convert-source-map": {
       "version": "1.1.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/convert-source-map/-/convert-source-map-1.1.3.tgz",
@@ -3081,8 +3438,7 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-decorators": {
       "version": "0.14.0",
@@ -3098,6 +3454,42 @@
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+      "requires": {
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0",
+        "require-from-string": "^2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -3270,6 +3662,14 @@
         "lodash.get": "^4.0.0"
       }
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/dashdash/-/dashdash-1.14.1.tgz",
@@ -3282,6 +3682,11 @@
       "version": "0.1.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",
@@ -3296,10 +3701,42 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+        }
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -3346,7 +3783,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "dev": true,
       "requires": {
         "is-descriptor": "^1.0.0"
       }
@@ -3452,8 +3888,7 @@
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-      "dev": true
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
     "detective": {
       "version": "4.7.1",
@@ -3473,6 +3908,7 @@
       "version": "1.0.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
       "requires": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -3492,6 +3928,30 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      }
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "requires": {
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "discontinuous-range": {
@@ -3580,9 +4040,9 @@
       }
     },
     "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -3615,46 +4075,6 @@
       "version": "0.1.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "duplexify": {
-      "version": "3.5.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/duplexify/-/duplexify-3.5.3.tgz",
-      "integrity": "sha1-i1gYgA35L9ASWyeriWSRkShYJD4=",
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha1-yUbD9H+n2Oq8C2FQ9KEvaaRXQHE=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -3715,11 +4135,6 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
-    "email-validator": {
-      "version": "1.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/email-validator/-/email-validator-1.1.1.tgz",
-      "integrity": "sha1-sH8757rB3AmbxD519q45n1UtWoA="
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3733,19 +4148,48 @@
         "iconv-lite": "~0.4.13"
       }
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "entities": {
       "version": "1.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
+    },
+    "env-ci": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-1.7.2.tgz",
+      "integrity": "sha512-FyxH6t3kg8l2ha507BQYgTA3G7p4Xntx+TwjkNuBf96mKD1p/tTpaU3jJinCBzXUJb9zb+X/EyvaOiOHs2JVGA==",
+      "requires": {
+        "execa": "^0.10.0",
+        "java-properties": "^0.2.9"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
     },
     "envify": {
       "version": "3.4.1",
@@ -4562,7 +5006,6 @@
       "version": "2.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
       "requires": {
         "is-extendable": "^0.1.0"
       }
@@ -4609,8 +5052,345 @@
     },
     "fast-diff": {
       "version": "1.1.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha1-S2LEK44D3j+EhGC2OQeZIGldAVQ="
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+    },
+    "fast-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.0.1",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.1",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+          "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          },
+          "dependencies": {
+            "regex-not": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+              "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+              "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            }
+          }
+        }
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -4748,11 +5528,6 @@
         "repeat-string": "^1.5.2"
       }
     },
-    "filled-array": {
-      "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/filled-array/-/filled-array-1.1.0.tgz",
-      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
-    },
     "finalhandler": {
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/finalhandler/-/finalhandler-1.1.0.tgz",
@@ -4874,7 +5649,6 @@
       "version": "0.2.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -4890,15 +5664,57 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
-    "fs-write-stream-atomic": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
-      "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "fs-copy-file-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz",
+      "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ=="
+    },
+    "fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
       "requires": {
         "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -5740,9 +6556,14 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
     "get-stdin": {
       "version": "5.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/get-stdin/-/get-stdin-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
     },
     "get-stream": {
@@ -5753,8 +6574,7 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
@@ -5762,6 +6582,100 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "git-log-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+      "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+      "requires": {
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "split2": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+          "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+          "requires": {
+            "through2": "~2.0.0"
+          }
+        },
+        "stream-combiner2": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+          "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+          "requires": {
+            "duplexer2": "~0.1.0",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "git-up": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-2.0.10.tgz",
+      "integrity": "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^1.3.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-8.3.1.tgz",
+      "integrity": "sha512-r/FxXIdfgdSO+V2zl4ZK1JGYkHT9nqVRSzom5WsYPLg3XzeBeKPl3R/6X9E9ZJRx/sE/dXwXtfl+Zp7YL8ktWQ==",
+      "requires": {
+        "git-up": "^2.0.0",
+        "parse-domain": "^2.0.0"
       }
     },
     "glob": {
@@ -5792,6 +6706,11 @@
       "requires": {
         "is-glob": "^2.0.0"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global": {
       "version": "4.3.2",
@@ -5851,82 +6770,15 @@
         }
       }
     },
-    "got": {
-      "version": "5.7.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-      "requires": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^3.0.0",
-        "unzip-response": "^1.0.2",
-        "url-parse-lax": "^1.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "requires": {
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha1-yUbD9H+n2Oq8C2FQ9KEvaaRXQHE=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graphlib": {
-      "version": "2.1.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha1-av4a/MUUhVXseZ5JkFZ5W9aTjIc=",
-      "requires": {
-        "lodash": "^4.11.1"
-      }
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
     },
     "growly": {
       "version": "1.3.0",
@@ -5938,7 +6790,6 @@
       "version": "4.0.11",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
       "requires": {
         "async": "^1.4.0",
         "optimist": "^0.6.1",
@@ -5949,14 +6800,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "^0.1.1",
@@ -5968,7 +6817,6 @@
           "version": "2.8.29",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
           "optional": true,
           "requires": {
             "source-map": "~0.5.1",
@@ -5980,7 +6828,6 @@
               "version": "0.5.7",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/source-map/-/source-map-0.5.7.tgz",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
               "optional": true
             }
           }
@@ -5989,14 +6836,12 @@
           "version": "0.1.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "^1.0.2",
@@ -6042,20 +6887,10 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "has-own-property-x": {
-      "version": "3.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
-      "integrity": "sha1-HEsRKld8jLWAVGlVblS26Vnk3tk=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "to-object-x": "^1.5.0",
-        "to-property-key-x": "^2.0.2"
-      }
-    },
     "has-symbol-support-x": {
-      "version": "1.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-      "integrity": "sha1-ZuwuN34MfXzO2wejqE13UQ/xvEw="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -6065,8 +6900,8 @@
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -6075,7 +6910,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "dev": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -6085,8 +6919,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -6094,7 +6927,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -6104,7 +6936,6 @@
           "version": "3.0.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -6113,7 +6944,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -6124,25 +6954,9 @@
           "version": "4.0.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
-        }
-      }
-    },
-    "hasbin": {
-      "version": "1.2.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/hasbin/-/hasbin-1.2.3.tgz",
-      "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
-      "requires": {
-        "async": "~1.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
     },
@@ -6182,6 +6996,11 @@
         }
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
     "help": {
       "version": "3.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/help/-/help-3.0.2.tgz",
@@ -6210,6 +7029,11 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
       }
+    },
+    "hook-std": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-0.4.0.tgz",
+      "integrity": "sha1-+osvhNNYdjE3y30X4zCLKHFL0XQ="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -6276,6 +7100,11 @@
         }
       }
     },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/http-errors/-/http-errors-1.6.2.tgz",
@@ -6291,6 +7120,25 @@
           "version": "1.1.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/depd/-/depd-1.1.1.tgz",
           "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        }
+      }
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -6352,22 +7200,31 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-    },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
-      "dev": true
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE="
     },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
+      }
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -6414,20 +7271,15 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
     },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "infinity-agent": {
-      "version": "2.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/infinity-agent/-/infinity-agent-2.0.3.tgz",
-      "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY="
-    },
-    "infinity-x": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/infinity-x/-/infinity-x-1.0.0.tgz",
-      "integrity": "sha1-zqLXUYHYIJYbD3LXjnxOBv3VWgc="
     },
     "inflight": {
       "version": "1.0.6",
@@ -6534,6 +7386,15 @@
         }
       }
     },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/invariant/-/invariant-2.2.2.tgz",
@@ -6556,7 +7417,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-      "dev": true,
       "requires": {
         "kind-of": "^6.0.0"
       },
@@ -6564,21 +7424,8 @@
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-          "dev": true
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
         }
-      }
-    },
-    "is-array-buffer-x": {
-      "version": "1.7.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha1-SwsQQntkqjQ3dnrfT8B3AsWbI3E=",
-      "requires": {
-        "attempt-x": "^1.1.0",
-        "has-to-string-tag-x": "^1.4.1",
-        "is-object-like-x": "^1.5.1",
-        "object-get-own-property-descriptor-x": "^3.2.0",
-        "to-string-tag-x": "^1.4.1"
       }
     },
     "is-arrayish": {
@@ -6632,7 +7479,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-      "dev": true,
       "requires": {
         "kind-of": "^6.0.0"
       },
@@ -6640,21 +7486,20 @@
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-          "dev": true
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
         }
       }
     },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-      "dev": true,
       "requires": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -6664,10 +7509,14 @@
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-          "dev": true
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
         }
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -6692,29 +7541,12 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
-    "is-falsey-x": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
-      "integrity": "sha1-xGmVGtyVuLP9v5CSmzNafek30X8=",
-      "requires": {
-        "to-boolean-x": "^1.0.1"
-      }
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
         "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-finite-x": {
-      "version": "3.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-finite-x/-/is-finite-x-3.0.2.tgz",
-      "integrity": "sha1-puxoPPsrwakYof9Z0XjtvOpU96Y=",
-      "requires": {
-        "infinity-x": "^1.0.0",
-        "is-nan-x": "^1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -6730,21 +7562,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-function/-/is-function-1.0.1.tgz",
       "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
-    "is-function-x": {
-      "version": "3.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-function-x/-/is-function-x-3.3.0.tgz",
-      "integrity": "sha1-fRa8EThT2yBtXkCosyyvmb1P98A=",
-      "requires": {
-        "attempt-x": "^1.1.1",
-        "has-to-string-tag-x": "^1.4.1",
-        "is-falsey-x": "^1.0.1",
-        "is-primitive": "^2.0.0",
-        "normalize-space-x": "^3.0.0",
-        "replace-comments-x": "^2.0.0",
-        "to-boolean-x": "^1.0.1",
-        "to-string-tag-x": "^1.4.2"
-      }
-    },
     "is-generator-fn": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
@@ -6757,18 +7574,6 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
         "is-extglob": "^1.0.0"
-      }
-    },
-    "is-index-x": {
-      "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-index-x/-/is-index-x-1.1.0.tgz",
-      "integrity": "sha1-Q9rJezoE8wGRUwgz9FrDUAFoLuI=",
-      "requires": {
-        "math-clamp-x": "^1.2.0",
-        "max-safe-integer": "^1.0.1",
-        "to-integer-x": "^3.0.0",
-        "to-number-x": "^2.0.0",
-        "to-string-symbols-supported-x": "^1.0.0"
       }
     },
     "is-installed-globally": {
@@ -6797,20 +7602,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "is-nan-x": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-nan-x/-/is-nan-x-1.0.1.tgz",
-      "integrity": "sha1-3nR+vMi93rZvNnwXysp+uoQ4VcA="
-    },
-    "is-nil-x": {
-      "version": "1.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-nil-x/-/is-nil-x-1.4.1.tgz",
-      "integrity": "sha1-vZ57CLTNcy+dy94T2TKRuy7C4kg=",
-      "requires": {
-        "lodash.isnull": "^3.0.0",
-        "validate.io-undefined": "^1.0.3"
-      }
-    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-npm/-/is-npm-1.0.0.tgz",
@@ -6835,14 +7626,10 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
-    "is-object-like-x": {
-      "version": "1.6.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-object-like-x/-/is-object-like-x-1.6.0.tgz",
-      "integrity": "sha1-qMSpW9a5XbF04ORzAXGhYOxzvoI=",
-      "requires": {
-        "is-function-x": "^3.3.0",
-        "is-primitive": "^2.0.0"
-      }
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-odd": {
       "version": "1.0.0",
@@ -6887,6 +7674,11 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6915,7 +7707,8 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
@@ -6947,6 +7740,14 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
+    "is-ssh": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.0.tgz",
+      "integrity": "sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=",
+      "requires": {
+        "protocols": "^1.1.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-stream/-/is-stream-1.1.0.tgz",
@@ -6955,18 +7756,27 @@
     "is-string": {
       "version": "1.0.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
     },
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "requires": {
+        "text-extensions": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -6977,6 +7787,11 @@
       "version": "0.2.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "0.0.1",
@@ -7021,6 +7836,17 @@
       "version": "0.1.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "issue-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-2.2.0.tgz",
+      "integrity": "sha512-qBm9P//mcpIosDX0GU29TJkOcIIyF4PMnetfU6yfWsukLRQJPUWdJuYFjEkHlW5bxCbmEkpBnkaAPiTmCYCNDQ==",
+      "requires": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1"
+      }
     },
     "istanbul-api": {
       "version": "1.2.2",
@@ -7138,6 +7964,20 @@
       "requires": {
         "handlebars": "^4.0.3"
       }
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
+    "java-properties": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
+      "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w=="
     },
     "jest": {
       "version": "22.3.0",
@@ -8228,9 +9068,9 @@
       }
     },
     "jju": {
-      "version": "1.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/jju/-/jju-1.3.0.tgz",
-      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
     },
     "joi": {
       "version": "6.10.1",
@@ -8339,9 +9179,19 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
       "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
       "requires": {
         "jju": "^1.1.0"
@@ -8380,6 +9230,14 @@
       "version": "0.5.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -8466,6 +9324,14 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/key-tree-store/-/key-tree-store-1.3.0.tgz",
       "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
     },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
@@ -8484,18 +9350,11 @@
         "stream-splicer": "^1.1.0"
       }
     },
-    "latest-version": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/latest-version/-/latest-version-2.0.0.tgz",
-      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-      "requires": {
-        "package-json": "^2.0.0"
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "optional": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -8547,6 +9406,7 @@
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -8559,6 +9419,7 @@
           "version": "2.0.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -8717,7 +9578,6 @@
       "version": "2.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -8726,8 +9586,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
     },
@@ -8749,26 +9608,16 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
     },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
-    },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-    },
-    "lodash.defaultsdeep": {
-      "version": "4.6.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
-      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E="
     },
     "lodash.endswith": {
       "version": "4.2.1",
@@ -8813,11 +9662,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
-    "lodash.isnull": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
-    },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
@@ -8838,11 +9682,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
-    "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha1-Y5BX5ybDr72z59QnQcqo1uQzWSc="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -8859,6 +9698,11 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
       "integrity": "sha1-xZjErc4YiiflMUVzHNxsDnF3YAw=",
       "dev": true
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
     "log-update": {
       "version": "1.0.2",
@@ -8880,6 +9724,15 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
         "js-tokens": "^3.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -8938,8 +9791,12 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
     },
     "map-stream": {
       "version": "0.1.0",
@@ -8951,32 +9808,26 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
     },
-    "math-clamp-x": {
-      "version": "1.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "integrity": "sha1-i1N74GRbu6fuc+4WCR59YBjF7c8=",
-      "requires": {
-        "to-number-x": "^2.0.0"
-      }
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
     },
-    "math-sign-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/math-sign-x/-/math-sign-x-3.0.0.tgz",
-      "integrity": "sha1-1ShgIrSOFQw4RymoYELgg1Jkw+0=",
+    "marked-terminal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-2.0.0.tgz",
+      "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
       "requires": {
-        "is-nan-x": "^1.0.1",
-        "to-number-x": "^2.0.0"
+        "cardinal": "^1.0.0",
+        "chalk": "^1.1.3",
+        "cli-table": "^0.3.1",
+        "lodash.assign": "^4.2.0",
+        "node-emoji": "^1.4.1"
       }
-    },
-    "max-safe-integer": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
     },
     "md5": {
       "version": "2.2.1",
@@ -9006,9 +9857,96 @@
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "meow": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
       }
     },
     "merge": {
@@ -9062,6 +10000,11 @@
           }
         }
       }
+    },
+    "merge2": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
     },
     "methods": {
       "version": "1.1.2",
@@ -9118,8 +10061,12 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
-      "dev": true
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "min-document": {
       "version": "2.19.0",
@@ -9152,11 +10099,19 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
-      "dev": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -9166,26 +10121,9 @@
           "version": "1.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
-        }
-      }
-    },
-    "mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "requires": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
         }
       }
     },
@@ -9196,6 +10134,74 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
+    "modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
     },
     "module-deps": {
       "version": "3.9.1",
@@ -9275,11 +10281,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
-    "nan-x": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/nan-x/-/nan-x-1.0.0.tgz",
-      "integrity": "sha1-DueOjRzQWS1bQmCllAFUVFxhwSE="
-    },
     "nanomatch": {
       "version": "1.2.7",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/nanomatch/-/nanomatch-1.2.7.tgz",
@@ -9325,44 +10326,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nconf": {
-      "version": "0.7.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/nconf/-/nconf-0.7.2.tgz",
-      "integrity": "sha1-oF/fItwBw3jdXE3yfy3JC5qouwA=",
-      "requires": {
-        "async": "~0.9.0",
-        "ini": "1.x.x",
-        "yargs": "~3.15.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "yargs": {
-          "version": "3.15.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/yargs/-/yargs-3.15.0.tgz",
-          "integrity": "sha1-PZRG7yH7N5GzmFaQZi5LloPH8YE=",
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "^0.1.1"
-          }
-        }
-      }
-    },
     "nearley": {
       "version": "2.11.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/nearley/-/nearley-2.11.1.tgz",
@@ -9375,35 +10338,36 @@
         "semver": "^5.4.1"
       }
     },
-    "needle": {
-      "version": "2.1.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/needle/-/needle-2.1.2.tgz",
-      "integrity": "sha1-M+hutW7PF2EpmUjui9H0A838ITc=",
-      "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4"
-      }
-    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
-    "nested-error-stacks": {
-      "version": "1.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
-      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-      "requires": {
-        "inherits": "~2.0.1"
-      }
+    "nerf-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo="
+    },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
     },
     "node-alias": {
       "version": "1.0.4",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/node-alias/-/node-alias-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/node-alias/-/node-alias-1.0.4.tgz",
       "integrity": "sha1-HxuRa1a56iQcATX5fO1pQPVW8pI=",
       "requires": {
         "chalk": "^1.1.1",
         "lodash": "^4.2.0"
+      }
+    },
+    "node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "requires": {
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-ews": {
@@ -9598,11 +10562,6 @@
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
     "node-xmpp-caps": {
       "version": "0.0.2",
@@ -10014,11 +10973,6 @@
         "abbrev": "1"
       }
     },
-    "normalize-git-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-      "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q="
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -10038,19 +10992,14 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
-    "normalize-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
-      "integrity": "sha1-F5B9bHxySk+VZ0ccuzGVU7wPiII=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "trim-x": "^3.0.0",
-        "white-space-x": "^3.0.0"
-      }
+    "normalize-url": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.2.0.tgz",
+      "integrity": "sha512-WvF3Myk0NhXkG8S9bygFM4IC1KOvnVJGq0QoGeoqOYOBeinBZp5ybW3QuYbTc89lkWBMM9ZBO4QGRoc0353kKA=="
     },
     "npm": {
       "version": "3.10.10",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/npm/-/npm-3.10.10.tgz",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-3.10.10.tgz",
       "integrity": "sha1-Wx1XfkyIadbIYDvInpzRY3MD5G4=",
       "requires": {
         "abbrev": "~1.0.9",
@@ -10209,11 +11158,6 @@
             }
           }
         },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
@@ -10227,11 +11171,6 @@
               "bundled": true
             }
           }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "debuglog": {
           "version": "1.0.1",
@@ -10256,6 +11195,16 @@
             "graceful-fs": "^4.1.2",
             "path-is-inside": "^1.0.1",
             "rimraf": "^2.5.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.8",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "fstream": {
@@ -10444,10 +11393,18 @@
                         "balanced-match": {
                           "version": "0.4.2",
                           "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
                         }
                       }
                     }
                   }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true
                 }
               }
             },
@@ -10459,11 +11416,6 @@
               }
             }
           }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "lockfile": {
           "version": "1.0.2",
@@ -10774,6 +11726,10 @@
             "abbrev": "1"
           }
         },
+        "normalize-git-url": {
+          "version": "3.0.2",
+          "bundled": true
+        },
         "normalize-package-data": {
           "version": "2.3.5",
           "bundled": true,
@@ -10802,6 +11758,13 @@
         "npm-cache-filename": {
           "version": "1.0.2",
           "bundled": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^2.3.0 || 3.x || 4 || 5"
+          }
         },
         "npm-package-arg": {
           "version": "4.2.0",
@@ -10848,8 +11811,24 @@
                     "util-deprecate": "~1.0.1"
                   },
                   "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
                     "process-nextick-args": {
                       "version": "1.0.7",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
                       "bundled": true
                     }
                   }
@@ -10859,11 +11838,6 @@
                   "bundled": true
                 }
               }
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "npmlog": {
               "version": "3.1.2",
@@ -10984,11 +11958,6 @@
             "retry": {
               "version": "0.10.0",
               "bundled": true
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
@@ -11132,11 +12101,6 @@
             }
           }
         },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
-        },
         "path-is-inside": {
           "version": "1.0.2",
           "bundled": true
@@ -11190,11 +12154,6 @@
             "normalize-package-data": "^2.0.0"
           },
           "dependencies": {
-            "concat-map": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-            },
             "glob": {
               "version": "6.0.4",
               "bundled": true,
@@ -11224,10 +12183,18 @@
                         "balanced-match": {
                           "version": "0.4.2",
                           "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
                         }
                       }
                     }
                   }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true
                 }
               }
             },
@@ -11243,11 +12210,6 @@
                   "bundled": true
                 }
               }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
             }
           }
         },
@@ -11279,12 +12241,20 @@
               "version": "1.0.0",
               "bundled": true
             },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
             "isarray": {
               "version": "1.0.0",
               "bundled": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
               "bundled": true
             },
             "util-deprecate": {
@@ -11301,6 +12271,14 @@
             "dezalgo": "^1.0.0",
             "graceful-fs": "^4.1.2",
             "once": "^1.3.0"
+          }
+        },
+        "realize-package-specifier": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "dezalgo": "^1.0.1",
+            "npm-package-arg": "^4.1.1"
           }
         },
         "request": {
@@ -11761,16 +12739,6 @@
           "version": "2.0.1",
           "bundled": true
         },
-        "spdx-license-ids": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-          "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
@@ -11813,16 +12781,20 @@
           "bundled": true,
           "requires": {
             "unique-slug": "^2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "^0.1.4"
+              }
+            }
           }
         },
         "unpipe": {
           "version": "1.0.0",
           "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
@@ -11855,6 +12827,10 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.4",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "1.2.0",
                   "bundled": true
                 }
               }
@@ -11903,9 +12879,9 @@
       }
     },
     "npm-check-updates": {
-      "version": "2.14.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/npm-check-updates/-/npm-check-updates-2.14.0.tgz",
-      "integrity": "sha1-UZyBHYfBuHS9XMlnanTDZyTUg7E=",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-2.14.2.tgz",
+      "integrity": "sha512-kyrLnGIImPb4WK/S/4AgsxKZ21ztC9KP+6aNTZN31cGJm4+GyH+aNq7ASvvJQO3iOdg/c60qLdZVtLTOn4l0gQ==",
       "requires": {
         "bluebird": "^3.4.3",
         "chalk": "^1.1.3",
@@ -11923,26 +12899,8 @@
         "rc-config-loader": "^2.0.1",
         "semver": "^5.3.0",
         "semver-utils": "^1.1.1",
-        "snyk": "^1.25.1",
         "spawn-please": "^0.3.0",
         "update-notifier": "^2.2.0"
-      }
-    },
-    "npm-install-checks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
-      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-      "requires": {
-        "semver": "^2.3.0 || 3.x || 4 || 5"
-      }
-    },
-    "npm-package-arg": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
-      "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
-      "requires": {
-        "hosted-git-info": "^2.1.5",
-        "semver": "^5.1.0"
       }
     },
     "npm-run-path": {
@@ -11955,7 +12913,7 @@
     },
     "npmi": {
       "version": "2.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/npmi/-/npmi-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/npmi/-/npmi-2.0.1.tgz",
       "integrity": "sha1-MmB2V+G9R8qFerTp2Y8KDP+WvOo=",
       "requires": {
         "npm": "^3",
@@ -11964,7 +12922,7 @@
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
         }
       }
@@ -12003,7 +12961,6 @@
       "version": "0.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -12014,7 +12971,6 @@
           "version": "0.2.5",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -12023,7 +12979,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -12032,7 +12987,6 @@
           "version": "0.1.4",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -12041,7 +12995,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -12051,28 +13004,10 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-              "dev": true
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
             }
           }
         }
-      }
-    },
-    "object-get-own-property-descriptor-x": {
-      "version": "3.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha1-RkWFrQPmYQjtFmyZMluNLFupNxI=",
-      "requires": {
-        "attempt-x": "^1.1.0",
-        "has-own-property-x": "^3.1.1",
-        "has-symbol-support-x": "^1.4.1",
-        "is-falsey-x": "^1.0.0",
-        "is-index-x": "^1.0.0",
-        "is-primitive": "^2.0.0",
-        "is-string": "^1.0.4",
-        "property-is-enumerable-x": "^1.1.0",
-        "to-object-x": "^1.4.1",
-        "to-property-key-x": "^2.0.1"
       }
     },
     "object-inspect": {
@@ -12101,7 +13036,6 @@
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.0"
       },
@@ -12109,8 +13043,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -12205,11 +13138,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
-    "open": {
-      "version": "0.0.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
-    },
     "openurl": {
       "version": "1.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/openurl/-/openurl-1.1.1.tgz",
@@ -12219,7 +13147,6 @@
       "version": "0.6.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -12270,43 +13197,10 @@
         "lcid": "^1.0.0"
       }
     },
-    "os-name": {
-      "version": "1.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/os-name/-/os-name-1.0.3.tgz",
-      "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
-      "requires": {
-        "osx-release": "^1.0.0",
-        "win-release": "^1.0.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
-    "osx-release": {
-      "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/osx-release/-/osx-release-1.1.0.tgz",
-      "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
-      "requires": {
-        "minimist": "^1.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
     },
     "outpipe": {
       "version": "1.1.1",
@@ -12329,16 +13223,33 @@
         }
       }
     },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
+    "p-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-1.0.0.tgz",
+      "integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
+      "requires": {
+        "p-map": "^1.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
     "p-limit": {
       "version": "1.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
-      "dev": true,
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -12347,27 +13258,40 @@
       "version": "2.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+    },
+    "p-retry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
+      "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
+      "requires": {
+        "retry": "^0.12.0"
+      }
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true
-    },
-    "package-json": {
-      "version": "2.4.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/package-json/-/package-json-2.4.0.tgz",
-      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-      "requires": {
-        "got": "^5.0.0",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
-      }
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "pako": {
       "version": "0.2.9",
@@ -12394,6 +13318,72 @@
         "pbkdf2": "^3.0.3"
       }
     },
+    "parse-domain": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/parse-domain/-/parse-domain-2.1.2.tgz",
+      "integrity": "sha512-I1HuHXYL8hZp9MYf0jHZE2nW0qhJnqBAxKOR9sGCbiBoD3znYrp4nh3SH9dkt2+f6gEenEj6sh537FTNe+QBqg==",
+      "requires": {
+        "chai": "^4.1.2",
+        "fs-copy-file-sync": "^1.1.1",
+        "got": "^8.0.1",
+        "mkdirp": "^0.5.1",
+        "mocha": "^4.0.1"
+      },
+      "dependencies": {
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -12414,23 +13404,22 @@
         "trim": "0.0.1"
       }
     },
-    "parse-int-x": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/parse-int-x/-/parse-int-x-2.0.0.tgz",
-      "integrity": "sha1-n5edQRWTDfL0cGpBgQuccSQFVS8=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "nan-x": "^1.0.0",
-        "to-string-x": "^1.4.2",
-        "trim-left-x": "^3.0.0"
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parse-url": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-1.3.11.tgz",
+      "integrity": "sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
       }
     },
     "parse5": {
@@ -12446,8 +13435,7 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
       "version": "0.0.0",
@@ -12457,8 +13445,7 @@
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -12502,11 +13489,17 @@
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -12537,7 +13530,8 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -12586,8 +13580,7 @@
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "precond": {
       "version": "0.2.3",
@@ -12692,19 +13685,15 @@
         }
       }
     },
-    "property-is-enumerable-x": {
-      "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha1-fKSJF0ds0JFLN4Cb/QV3ag2UL28=",
-      "requires": {
-        "to-object-x": "^1.4.1",
-        "to-property-key-x": "^2.0.1"
-      }
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+    },
+    "protocols": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.6.tgz",
+      "integrity": "sha1-+LsmPqG1/Xp2BNJri+Ob13Z4v4o="
     },
     "proxy-addr": {
       "version": "2.0.2",
@@ -12714,11 +13703,6 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "ps-tree": {
       "version": "1.1.0",
@@ -12801,6 +13785,11 @@
       "version": "0.2.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
     },
     "raf": {
       "version": "3.4.0",
@@ -12921,8 +13910,8 @@
     },
     "rc-config-loader": {
       "version": "2.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/rc-config-loader/-/rc-config-loader-2.0.1.tgz",
-      "integrity": "sha1-jIRS9ZvdENRIpndi3M98GyR9uGA=",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.1.tgz",
+      "integrity": "sha512-OHr24Jb7nN6oaQOTRXxcQ2yJSK3SHA1dp2CZEfvRxsl/MbhFr4CYnkwn8DY37pKu7Eu18X4mYuWFxO6vpbFxtQ==",
       "requires": {
         "debug": "^2.2.0",
         "js-yaml": "^3.6.1",
@@ -12935,7 +13924,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
@@ -13051,44 +14040,6 @@
         }
       }
     },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha1-yUbD9H+n2Oq8C2FQ9KEvaaRXQHE=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "read-only-stream": {
       "version": "1.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/read-only-stream/-/read-only-stream-1.1.1.tgz",
@@ -13102,6 +14053,7 @@
       "version": "1.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -13112,6 +14064,7 @@
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -13199,15 +14152,6 @@
         "mute-stream": "0.0.5"
       }
     },
-    "realize-package-specifier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.3.tgz",
-      "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
-      "requires": {
-        "dezalgo": "^1.0.1",
-        "npm-package-arg": "^4.1.1"
-      }
-    },
     "realpath-native": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/realpath-native/-/realpath-native-1.0.0.tgz",
@@ -13254,21 +14198,27 @@
         }
       }
     },
-    "recursive-readdir": {
-      "version": "2.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
-      "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "requires": {
-        "minimatch": "3.0.3"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      }
+    },
+    "redeyed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+      "requires": {
+        "esprima": "~3.0.0"
       },
       "dependencies": {
-        "minimatch": {
-          "version": "3.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
+        "esprima": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
         }
       }
     },
@@ -13304,7 +14254,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/regex-not/-/regex-not-1.0.0.tgz",
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1"
       }
@@ -13372,15 +14321,6 @@
         "is-finite": "^1.0.0"
       }
     },
-    "replace-comments-x": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
-      "integrity": "sha1-pc7Bjv2RKq14p8PEtp0BdoVW0UA=",
-      "requires": {
-        "require-coercible-to-string-x": "^1.0.0",
-        "to-string-x": "^1.4.2"
-      }
-    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/request/-/request-2.83.0.tgz",
@@ -13441,15 +14381,6 @@
         "when": "^3.7.7"
       }
     },
-    "require-coercible-to-string-x": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
-      "integrity": "sha1-Nns+nKZ+ADJMQRsLSYRTp0zVVp4=",
-      "requires": {
-        "require-object-coercible-x": "^1.4.1",
-        "to-string-x": "^1.4.2"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/require-directory/-/require-directory-2.1.1.tgz",
@@ -13464,14 +14395,6 @@
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "require-object-coercible-x": {
-      "version": "1.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
-      "integrity": "sha1-dbn7W9otFc9wWlcU8QjotAyj6y4=",
-      "requires": {
-        "is-nil-x": "^1.4.1"
-      }
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -13517,8 +14440,15 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -13532,13 +14462,18 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
-      "dev": true
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "optional": true,
       "requires": {
         "align-text": "^0.1.1"
       }
@@ -13623,11 +14558,6 @@
         "once": "^1.3.0"
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-    },
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/rx-lite/-/rx-lite-3.1.2.tgz",
@@ -13646,6 +14576,14 @@
       "version": "5.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "sane": {
       "version": "2.4.1",
@@ -13696,6 +14634,271 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/selectn/-/selectn-0.9.6.tgz",
       "integrity": "sha1-vYc6VW0Y+W2FFfyRUD7G/zmP+aI="
     },
+    "semantic-release": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-13.4.1.tgz",
+      "integrity": "sha512-WkvUspFIajaP6S/Thsf1uUKxcLJmpKU+RktYlWdu2G/hRssArvQZBZubL6RkSsYKY6sAeOKH0r3gGLe+ue5J7w==",
+      "requires": {
+        "@semantic-release/commit-analyzer": "^5.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^4.1.0",
+        "@semantic-release/npm": "^3.1.0",
+        "@semantic-release/release-notes-generator": "^6.0.0",
+        "aggregate-error": "^1.0.0",
+        "chalk": "^2.3.0",
+        "commander": "^2.11.0",
+        "cosmiconfig": "^4.0.0",
+        "debug": "^3.1.0",
+        "env-ci": "^1.0.0",
+        "execa": "^0.9.0",
+        "get-stream": "^3.0.0",
+        "git-log-parser": "^1.2.0",
+        "git-url-parse": "^8.1.0",
+        "hook-std": "^0.4.0",
+        "lodash": "^4.17.4",
+        "marked": "^0.3.9",
+        "marked-terminal": "^2.0.0",
+        "p-locate": "^2.0.0",
+        "p-reduce": "^1.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve-from": "^4.0.0",
+        "semver": "^5.4.1",
+        "yargs": "^11.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+          "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+          "requires": {
+            "color-name": "1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+          "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          },
+          "dependencies": {
+            "execa": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            }
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "semantic-ui-react": {
       "version": "0.77.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/semantic-ui-react/-/semantic-ui-react-0.77.2.tgz",
@@ -13722,9 +14925,9 @@
       }
     },
     "semver-utils": {
-      "version": "1.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/semver-utils/-/semver-utils-1.1.1.tgz",
-      "integrity": "sha1-J9kv7DTSfPpCcH07QNAlrphV8t8="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.2.tgz",
+      "integrity": "sha512-+RvtdCZJdLJXN6ozVqbypYII/m4snihgWvmFHW8iWusxqGVdEP31QdUVVaC6GeJ9EYE0JCMdWiNlLF3edjifEw=="
     },
     "send": {
       "version": "0.16.1",
@@ -13773,7 +14976,6 @@
       "version": "0.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
       "requires": {
         "to-object-path": "^0.3.0"
       }
@@ -13787,7 +14989,6 @@
       "version": "2.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -13812,32 +15013,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "shallow-clone": {
-      "version": "0.1.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/shallow-clone/-/shallow-clone-0.1.2.tgz",
-      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-      "requires": {
-        "is-extendable": "^0.1.1",
-        "kind-of": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "mixin-object": "^2.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "2.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-2.0.1.tgz",
-          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "requires": {
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
       }
     },
     "shasum": {
@@ -13924,16 +15099,10 @@
         }
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-    },
     "snapdragon": {
       "version": "0.8.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snapdragon/-/snapdragon-0.8.1.tgz",
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
-      "dev": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -13949,7 +15118,6 @@
           "version": "0.2.5",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -13958,7 +15126,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -13967,7 +15134,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -13978,7 +15144,6 @@
           "version": "0.1.4",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -13987,7 +15152,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -13998,7 +15162,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -14008,14 +15171,12 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-          "dev": true
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -14023,7 +15184,6 @@
       "version": "2.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
-      "dev": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -14033,8 +15193,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -14042,7 +15201,6 @@
       "version": "3.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
-      "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
       }
@@ -14059,385 +15217,6 @@
           "version": "4.2.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
-        }
-      }
-    },
-    "snyk": {
-      "version": "1.69.7",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk/-/snyk-1.69.7.tgz",
-      "integrity": "sha1-rIeaq7xCWqKot3kAqPbRwhuo0v4=",
-      "requires": {
-        "abbrev": "^1.0.7",
-        "ansi-escapes": "^1.3.0",
-        "chalk": "^1.1.1",
-        "configstore": "^1.2.0",
-        "debug": "^2.2.0",
-        "es6-promise": "^3.0.2",
-        "hasbin": "^1.2.3",
-        "inquirer": "1.0.3",
-        "needle": "^2.0.1",
-        "open": "^0.0.5",
-        "os-name": "^1.0.3",
-        "proxy-from-env": "^1.0.0",
-        "recursive-readdir": "^2.2.1",
-        "semver": "^5.1.0",
-        "snyk-config": "1.0.1",
-        "snyk-go-plugin": "1.4.5",
-        "snyk-gradle-plugin": "1.2.0",
-        "snyk-module": "1.8.1",
-        "snyk-mvn-plugin": "1.1.1",
-        "snyk-nuget-plugin": "1.3.9",
-        "snyk-php-plugin": "1.3.2",
-        "snyk-policy": "^1.10.1",
-        "snyk-python-plugin": "1.5.6",
-        "snyk-resolve": "1.0.0",
-        "snyk-resolve-deps": "1.7.0",
-        "snyk-sbt-plugin": "1.2.3",
-        "snyk-tree": "^1.0.0",
-        "snyk-try-require": "^1.2.0",
-        "tempfile": "^1.1.1",
-        "then-fs": "^2.0.0",
-        "undefsafe": "0.0.3",
-        "update-notifier": "^0.5.0",
-        "url": "^0.11.0",
-        "uuid": "^3.0.1"
-      },
-      "dependencies": {
-        "cli-width": {
-          "version": "2.2.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/cli-width/-/cli-width-2.2.0.tgz",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
-        "got": {
-          "version": "3.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/got/-/got-3.3.1.tgz",
-          "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
-          "requires": {
-            "duplexify": "^3.2.0",
-            "infinity-agent": "^2.0.0",
-            "is-redirect": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "nested-error-stacks": "^1.0.0",
-            "object-assign": "^3.0.0",
-            "prepend-http": "^1.0.0",
-            "read-all-stream": "^3.0.0",
-            "timed-out": "^2.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "1.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/inquirer/-/inquirer-1.0.3.tgz",
-          "integrity": "sha1-6+OglIVxvMRszMvi+bzsJR6YS9A=",
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.6",
-            "pinkie-promise": "^2.0.0",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "latest-version": {
-          "version": "1.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/latest-version/-/latest-version-1.0.1.tgz",
-          "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
-          "requires": {
-            "package-json": "^1.0.0"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.6",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/mute-stream/-/mute-stream-0.0.6.tgz",
-          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        },
-        "package-json": {
-          "version": "1.2.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/package-json/-/package-json-1.2.0.tgz",
-          "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
-          "requires": {
-            "got": "^3.2.0",
-            "registry-url": "^3.0.0"
-          }
-        },
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "requires": {
-            "is-promise": "^2.1.0"
-          }
-        },
-        "timed-out": {
-          "version": "2.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/timed-out/-/timed-out-2.0.0.tgz",
-          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
-        },
-        "update-notifier": {
-          "version": "0.5.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/update-notifier/-/update-notifier-0.5.0.tgz",
-          "integrity": "sha1-B7XcIGazYnqztPUwEw9+3doHpMw=",
-          "requires": {
-            "chalk": "^1.0.0",
-            "configstore": "^1.0.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^1.0.0",
-            "repeating": "^1.1.2",
-            "semver-diff": "^2.0.0",
-            "string-length": "^1.0.0"
-          }
-        },
-        "url": {
-          "version": "0.11.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/url/-/url-0.11.0.tgz",
-          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          }
-        }
-      }
-    },
-    "snyk-config": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-config/-/snyk-config-1.0.1.tgz",
-      "integrity": "sha1-8nrsJJiyQCescZIUAmUhWRERUI8=",
-      "requires": {
-        "debug": "^2.2.0",
-        "nconf": "^0.7.2",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "snyk-go-plugin": {
-      "version": "1.4.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-go-plugin/-/snyk-go-plugin-1.4.5.tgz",
-      "integrity": "sha1-v0YmVsqt4GA5cLaOdW9LOJw66qo=",
-      "requires": {
-        "graphlib": "^2.1.1",
-        "toml": "^2.3.2"
-      }
-    },
-    "snyk-gradle-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-gradle-plugin/-/snyk-gradle-plugin-1.2.0.tgz",
-      "integrity": "sha1-71rqXRMpBcvwMVxy2dlrJKpKdd0=",
-      "requires": {
-        "clone-deep": "^0.3.0"
-      }
-    },
-    "snyk-module": {
-      "version": "1.8.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-module/-/snyk-module-1.8.1.tgz",
-      "integrity": "sha1-MdUID7HA39b6hWfdNKUj/QK/H8o=",
-      "requires": {
-        "debug": "^2.2.0",
-        "hosted-git-info": "^2.1.4"
-      }
-    },
-    "snyk-mvn-plugin": {
-      "version": "1.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.1.tgz",
-      "integrity": "sha1-FcExMaNo3eSHdj3pNVetX7lXL/4="
-    },
-    "snyk-nuget-plugin": {
-      "version": "1.3.9",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz",
-      "integrity": "sha1-vNxQPq/p8+60Akt1be1NDDsmXRI=",
-      "requires": {
-        "debug": "^3.1.0",
-        "es6-promise": "^4.1.1",
-        "xml2js": "^0.4.17",
-        "zip": "^1.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "xml2js": {
-          "version": "0.4.19",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/xml2js/-/xml2js-0.4.19.tgz",
-          "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
-          "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": "~9.0.1"
-          }
-        }
-      }
-    },
-    "snyk-php-plugin": {
-      "version": "1.3.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz",
-      "integrity": "sha1-UcGRcd7gzTUVinqoNf4CqX3ISrg=",
-      "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "snyk-policy": {
-      "version": "1.10.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-policy/-/snyk-policy-1.10.1.tgz",
-      "integrity": "sha1-saJsiu9SnGFgSso4IRHlNdURt2M=",
-      "requires": {
-        "debug": "^2.2.0",
-        "email-validator": "^1.1.1",
-        "es6-promise": "^3.1.2",
-        "js-yaml": "^3.5.3",
-        "lodash.clonedeep": "^4.3.1",
-        "semver": "^5.1.0",
-        "snyk-module": "^1.8.1",
-        "snyk-resolve": "^1.0.0",
-        "snyk-try-require": "^1.1.1",
-        "then-fs": "^2.0.0"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        }
-      }
-    },
-    "snyk-python-plugin": {
-      "version": "1.5.6",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz",
-      "integrity": "sha1-zjHwtofyPRJ/evORgOopAbKJH+w="
-    },
-    "snyk-resolve": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-resolve/-/snyk-resolve-1.0.0.tgz",
-      "integrity": "sha1-u+kZbTf1fDklHmvnXM3Vsgl+maI=",
-      "requires": {
-        "debug": "^2.2.0",
-        "then-fs": "^2.0.0"
-      }
-    },
-    "snyk-resolve-deps": {
-      "version": "1.7.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-resolve-deps/-/snyk-resolve-deps-1.7.0.tgz",
-      "integrity": "sha1-E3Q6BYQ33/iQuq9DfDM8lmp0PLY=",
-      "requires": {
-        "abbrev": "^1.0.7",
-        "ansicolors": "^0.3.2",
-        "clite": "^0.3.0",
-        "debug": "^2.2.0",
-        "es6-promise": "^3.0.2",
-        "lodash": "^4.0.0",
-        "lru-cache": "^4.0.0",
-        "minimist": "^1.2.0",
-        "semver": "^5.1.0",
-        "snyk-module": "^1.6.0",
-        "snyk-resolve": "^1.0.0",
-        "snyk-tree": "^1.0.0",
-        "snyk-try-require": "^1.1.1",
-        "then-fs": "^2.0.0"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
-    "snyk-sbt-plugin": {
-      "version": "1.2.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.3.tgz",
-      "integrity": "sha1-VhV4bxmCXuZKy1CxoEGEO0qcTg8=",
-      "requires": {
-        "debug": "^2.2.0"
-      }
-    },
-    "snyk-tree": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-tree/-/snyk-tree-1.0.0.tgz",
-      "integrity": "sha1-D7cxdtvzLngvGRAClBYESPkRHMg=",
-      "requires": {
-        "archy": "^1.0.0"
-      }
-    },
-    "snyk-try-require": {
-      "version": "1.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/snyk-try-require/-/snyk-try-require-1.2.0.tgz",
-      "integrity": "sha1-MPwrEcBwZFke41eAyCa+kTEvIUQ=",
-      "requires": {
-        "debug": "^2.2.0",
-        "es6-promise": "^3.1.2",
-        "lodash.clonedeep": "^4.3.0",
-        "lru-cache": "^4.0.0",
-        "then-fs": "^2.0.0"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
         }
       }
     },
@@ -14476,6 +15255,14 @@
         "object-path": "0.6.0"
       }
     },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.4.4",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/source-map/-/source-map-0.4.4.tgz",
@@ -14488,7 +15275,6 @@
       "version": "0.5.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
-      "dev": true,
       "requires": {
         "atob": "^2.0.0",
         "decode-uri-component": "^0.2.0",
@@ -14515,12 +15301,16 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "spawn-error-forwarder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk="
     },
     "spawn-please": {
       "version": "0.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/spawn-please/-/spawn-please-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/spawn-please/-/spawn-please-0.3.0.tgz",
       "integrity": "sha1-2zOOxM/2Orxp8dDgjO6euL69nRE="
     },
     "spdx-correct": {
@@ -14554,7 +15344,6 @@
       "version": "3.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
-      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       },
@@ -14563,7 +15352,6 @@
           "version": "3.0.2",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -14573,9 +15361,54 @@
           "version": "1.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -14610,7 +15443,6 @@
       "version": "0.1.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -14620,7 +15452,6 @@
           "version": "0.2.5",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -14629,7 +15460,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -14638,7 +15468,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -14649,7 +15478,6 @@
           "version": "0.1.4",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -14658,7 +15486,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -14669,7 +15496,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -14679,8 +15505,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-          "dev": true
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
@@ -14780,11 +15605,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
     "stream-splicer": {
       "version": "1.3.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/stream-splicer/-/stream-splicer-1.3.2.tgz",
@@ -14830,14 +15650,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string/-/string-3.3.3.tgz",
       "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
-    "string-length": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string-length/-/string-length-1.0.1.tgz",
-      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-      "requires": {
-        "strip-ansi": "^3.0.0"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string-width/-/string-width-1.0.2.tgz",
@@ -14879,6 +15691,11 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -15004,22 +15821,6 @@
         }
       }
     },
-    "tempfile": {
-      "version": "1.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/tempfile/-/tempfile-1.1.1.tgz",
-      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-      "requires": {
-        "os-tmpdir": "^1.0.0",
-        "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/term-size/-/term-size-1.2.0.tgz",
@@ -15068,29 +15869,16 @@
         }
       }
     },
+    "text-extensions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "then-fs": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/then-fs/-/then-fs-2.0.0.tgz",
-      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-      "requires": {
-        "promise": ">=3.2 <8"
-      },
-      "dependencies": {
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
     },
     "throat": {
       "version": "4.1.0",
@@ -15111,11 +15899,6 @@
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
       }
-    },
-    "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
     },
     "timers-browserify": {
       "version": "1.4.2",
@@ -15151,80 +15934,17 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
-    "to-boolean-x": {
-      "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-boolean-x/-/to-boolean-x-1.0.1.tgz",
-      "integrity": "sha1-ckEo2sxb6nWpOtRxvn7pJ3VhssE="
-    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
-    "to-integer-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-integer-x/-/to-integer-x-3.0.0.tgz",
-      "integrity": "sha1-nzuA5mjH8K5F5pJrQNlfUsGt3HQ=",
-      "requires": {
-        "is-finite-x": "^3.0.2",
-        "is-nan-x": "^1.0.1",
-        "math-sign-x": "^3.0.0",
-        "to-number-x": "^2.0.0"
-      }
-    },
-    "to-number-x": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-number-x/-/to-number-x-2.0.0.tgz",
-      "integrity": "sha1-yQmdfe2P0ycTKimH3y3Mi682300=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "nan-x": "^1.0.0",
-        "parse-int-x": "^2.0.0",
-        "to-primitive-x": "^1.1.0",
-        "trim-x": "^3.0.0"
-      }
-    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
-      }
-    },
-    "to-object-x": {
-      "version": "1.5.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-object-x/-/to-object-x-1.5.0.tgz",
-      "integrity": "sha1-vWndThBNd6zAzA2E9axI9jCuvjw=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-object-coercible-x": "^1.4.1"
-      }
-    },
-    "to-primitive-x": {
-      "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
-      "integrity": "sha1-Qc4sE+PiRuDl0KiCmgVnxgFYM/g=",
-      "requires": {
-        "has-symbol-support-x": "^1.4.1",
-        "is-date-object": "^1.0.1",
-        "is-function-x": "^3.2.0",
-        "is-nil-x": "^1.4.1",
-        "is-primitive": "^2.0.0",
-        "is-symbol": "^1.0.1",
-        "require-object-coercible-x": "^1.4.1",
-        "validate.io-undefined": "^1.0.3"
-      }
-    },
-    "to-property-key-x": {
-      "version": "2.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
-      "integrity": "sha1-sZqo4i+qD/fRwQLPvGV69zQTz6E=",
-      "requires": {
-        "has-symbol-support-x": "^1.4.1",
-        "to-primitive-x": "^1.1.0",
-        "to-string-x": "^1.4.2"
       }
     },
     "to-regex": {
@@ -15310,7 +16030,6 @@
       "version": "2.1.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -15320,49 +16039,11 @@
           "version": "3.0.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
         }
       }
-    },
-    "to-string-symbols-supported-x": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.0.tgz",
-      "integrity": "sha1-1DXrcjEv6IWxgEepbVnHVkFHaHI=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "has-symbol-support-x": "^1.4.1",
-        "is-symbol": "^1.0.1"
-      }
-    },
-    "to-string-tag-x": {
-      "version": "1.4.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
-      "integrity": "sha1-kWoMctL5PcJ/zP4OoM4mzXi+Id4=",
-      "requires": {
-        "lodash.isnull": "^3.0.0",
-        "validate.io-undefined": "^1.0.3"
-      }
-    },
-    "to-string-x": {
-      "version": "1.4.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-string-x/-/to-string-x-1.4.2.tgz",
-      "integrity": "sha1-fZolKOFZqSFOZoE3weEKBFq+Ynk=",
-      "requires": {
-        "is-symbol": "^1.0.1"
-      }
-    },
-    "to-utf8": {
-      "version": "0.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/to-utf8/-/to-utf8-0.0.1.tgz",
-      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
-    },
-    "toml": {
-      "version": "2.3.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs="
     },
     "topo": {
       "version": "1.1.0",
@@ -15417,44 +16098,30 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
-    "trim-left-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/trim-left-x/-/trim-left-x-3.0.0.tgz",
-      "integrity": "sha1-NWzwVYlnJrl1RCXoQTmIQukLTN8=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-coercible-to-string-x": "^1.0.0",
-        "white-space-x": "^3.0.0"
-      }
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+    },
+    "trim-off-newlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-    },
-    "trim-right-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/trim-right-x/-/trim-right-x-3.0.0.tgz",
-      "integrity": "sha1-KMTNN9WYH1Cs6bUuPOkQb00tIsA=",
-      "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-coercible-to-string-x": "^1.0.0",
-        "white-space-x": "^3.0.0"
-      }
-    },
-    "trim-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/trim-x/-/trim-x-3.0.0.tgz",
-      "integrity": "sha1-JO/c0Ce3SLv8JGoBOa0XSb7+8CQ=",
-      "requires": {
-        "trim-left-x": "^3.0.0",
-        "trim-right-x": "^3.0.0"
-      }
     },
     "tslib": {
       "version": "1.9.0",
@@ -15549,6 +16216,11 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/type-is/-/type-is-1.6.15.tgz",
@@ -15569,9 +16241,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
-      "version": "3.1.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
-      "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -15611,7 +16283,6 @@
       "version": "1.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "uglifyify": {
@@ -15643,11 +16314,6 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/umd/-/umd-3.0.1.tgz",
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4="
     },
-    "undefsafe": {
-      "version": "0.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/undefsafe/-/undefsafe-0.0.3.tgz",
-      "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8="
-    },
     "underscore": {
       "version": "1.7.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/underscore/-/underscore-1.7.0.tgz",
@@ -15657,7 +16323,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -15669,7 +16334,6 @@
           "version": "0.4.3",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -15677,14 +16341,6 @@
             "to-object-path": "^0.3.0"
           }
         }
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "requires": {
-        "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {
@@ -15695,6 +16351,11 @@
         "crypto-random-string": "^1.0.0"
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/unpipe/-/unpipe-1.0.0.tgz",
@@ -15704,7 +16365,6 @@
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "dev": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -15714,7 +16374,6 @@
           "version": "0.3.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "dev": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -15725,7 +16384,6 @@
               "version": "2.1.0",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -15735,27 +16393,19 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "upath": {
       "version": "1.0.2",
@@ -15961,8 +16611,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.10.3",
@@ -15993,6 +16642,16 @@
         "prepend-http": "^1.0.1"
       }
     },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
     "urlsafe-base64": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
@@ -16002,7 +16661,6 @@
       "version": "2.0.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/use/-/use-2.0.2.tgz",
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
-      "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "isobject": "^3.0.0",
@@ -16013,7 +16671,6 @@
           "version": "0.2.5",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -16022,7 +16679,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -16031,7 +16687,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16042,7 +16697,6 @@
           "version": "0.1.4",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -16051,7 +16705,6 @@
               "version": "3.2.2",
               "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16062,7 +16715,6 @@
           "version": "0.1.6",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -16072,20 +16724,17 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-          "dev": true
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         },
         "lazy-cache": {
           "version": "2.0.2",
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "dev": true,
           "requires": {
             "set-getter": "^0.1.0"
           }
@@ -16141,20 +16790,18 @@
         "spdx-expression-parse": "~1.0.0"
       }
     },
-    "validate.io-undefined": {
-      "version": "1.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vcap_services": {
-      "version": "0.3.4",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/vcap_services/-/vcap_services-0.3.4.tgz",
-      "integrity": "sha1-FUv5QEAlEqzKI98iY/xg72aEWto="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vcap_services/-/vcap_services-0.4.0.tgz",
+      "integrity": "sha512-eCMqdtOQnl8jRQNwpXD2zzXXD7AcC8fqjmCkmTO3L9jJpL7IWjipBHB28ipx0PEiOiEKPhzy776DcsoBoqfU3w==",
+      "requires": {
+        "semantic-release": "^13.1.1"
+      }
     },
     "verror": {
       "version": "1.10.0",
@@ -16673,51 +17320,100 @@
       }
     },
     "watson-developer-cloud": {
-      "version": "3.0.6",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/watson-developer-cloud/-/watson-developer-cloud-3.0.6.tgz",
-      "integrity": "sha1-HMoCZ6f1e+u0STH7K1kfmF4o2I4=",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/watson-developer-cloud/-/watson-developer-cloud-3.7.1.tgz",
+      "integrity": "sha512-m5M/Dge+9tOaFtuIA2bOSIjLCJq3GGMfBYRo633aHVTKvSUzT68EGwStHKqr4e243TPK1Lv8l/zSbOP364FlxA==",
       "requires": {
-        "@types/csv-stringify": "~1.4.1",
+        "@types/csv-stringify": "~1.4.2",
         "@types/extend": "~3.0.0",
         "@types/file-type": "~5.2.1",
         "@types/is-stream": "~1.1.0",
-        "@types/node": "~9.3.0",
-        "@types/request": "^2.0.11",
-        "async": "~2.6.0",
-        "buffer-from": "~0.1.1",
-        "cookie": "~0.3.1",
+        "@types/node": "~10.3.5",
+        "@types/request": "~2.47.1",
+        "async": "~2.6.1",
+        "buffer-from": "~1.1.0",
         "csv-stringify": "~1.0.2",
-        "extend": "~3.0.0",
-        "file-type": "~7.4.0",
+        "extend": "~3.0.1",
+        "file-type": "^7.7.1",
         "isstream": "~0.1.2",
-        "mime-types": "~2.1.17",
+        "mime-types": "~2.1.18",
         "object.omit": "~3.0.0",
         "object.pick": "~1.3.0",
-        "request": "~2.83.0",
-        "vcap_services": "~0.3.0",
-        "websocket": "~1.0.25"
+        "request": "~2.87.0",
+        "vcap_services": "~0.3.4",
+        "websocket": "~1.0.26"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.3.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.6.tgz",
+          "integrity": "sha512-h7VDRFL8IhdPw1JjiNVvhr+WynfKW09q2BOflIOA0yeuXNeXBP1bIRuBrysSryH4keaJ5bYUNp63aIyQL9YpDQ=="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
         "file-type": {
-          "version": "7.4.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/file-type/-/file-type-7.4.0.tgz",
-          "integrity": "sha1-KnyU9ioAMBULt9m2xwz6HT51nIY="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
+          "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
         },
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
         },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
         "object.omit": {
           "version": "3.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/object.omit/-/object.omit-3.0.0.tgz",
-          "integrity": "sha1-Dj7cL84rpU31V3/1KfbZe9ilIq8=",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
+          "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
           "requires": {
             "is-extendable": "^1.0.0"
           }
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "vcap_services": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/vcap_services/-/vcap_services-0.3.4.tgz",
+          "integrity": "sha1-FUv5QEAlEqzKI98iY/xg72aEWto="
         }
       }
     },
@@ -16742,9 +17438,9 @@
       }
     },
     "websocket": {
-      "version": "1.0.25",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/websocket/-/websocket-1.0.25.tgz",
-      "integrity": "sha1-mY7HkPCj6suLCLUKQ1ACZpKhGVg=",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
+      "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
       "requires": {
         "debug": "^2.2.0",
         "nan": "^2.3.3",
@@ -16788,32 +17484,6 @@
       "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "white-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/white-space-x/-/white-space-x-3.0.0.tgz",
-      "integrity": "sha1-yOMe1P7PTz/uvmUy5gRgCKZmo+E="
-    },
-    "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-      "requires": {
-        "string-width": "^1.0.1"
-      }
-    },
-    "win-release": {
-      "version": "1.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-      "requires": {
-        "semver": "^5.0.1"
       }
     },
     "window-size": {
@@ -16864,16 +17534,6 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
-    },
     "ws": {
       "version": "3.3.3",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ws/-/ws-3.3.3.tgz",
@@ -16889,14 +17549,6 @@
           "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ultron/-/ultron-1.1.1.tgz",
           "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
         }
-      }
-    },
-    "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "requires": {
-        "os-homedir": "^1.0.0"
       }
     },
     "xml-crypto": {
@@ -16960,30 +17612,6 @@
         "os-locale": "^1.4.0",
         "window-size": "^0.1.2",
         "y18n": "^3.2.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-      "requires": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        }
-      }
-    },
-    "zip": {
-      "version": "1.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/zip/-/zip-1.2.0.tgz",
-      "integrity": "sha1-rQrUImUwm+QutW/IYZThfCTmapw=",
-      "requires": {
-        "bops": "~0.1.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "botkit": "^0.6.7",
     "cfenv": "^1.0.3",
     "chart.js": "^2.7.1",
-    "dotenv": "^4.0.0",
+    "dotenv": "^6.0.0",
     "express": "^4.15.3",
     "express-browserify": "^1.0.2",
     "express-react-views": "^0.10.2",
     "g": "^2.0.1",
     "help": "^3.0.2",
     "moment": "^2.19.4",
-    "npm-check-updates": "^2.13.0",
+    "npm-check-updates": "^2.14.2",
     "parse5": "^4.0.0",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.1",
@@ -43,8 +43,8 @@
     "semantic-ui-react": "^0.77.1",
     "sort-by": "^1.2.0",
     "uglifyify": "^4.0.5",
-    "vcap_services": "^0.3.4",
-    "watson-developer-cloud": "^3.0.3"
+    "vcap_services": "^0.4.0",
+    "watson-developer-cloud": "^3.7.1"
   },
   "engines": {
     "node": "8.4.0"

--- a/server/index.js
+++ b/server/index.js
@@ -26,7 +26,7 @@ const queryString = require('query-string');
 const queryBuilder = require('./query-builder');
 const queryTrendBuilder = require('./query-builder-trending');
 const WatsonDiscoverySetup = require('../lib/watson-discovery-setup');
-const watson = require('watson-developer-cloud');
+const DiscoveryV1 = require('watson-developer-cloud/discovery/v1');
 const utils = require('../lib/utils');
 
 /**
@@ -49,10 +49,8 @@ arrayOfFiles.forEach(function(file) {
 // out of memory errors.
 //discoveryDocs = discoveryDocs.slice(0,100);
 
-const discovery = watson.discovery({
-  // uname/pwd will be pulled in from VCAP_SERVICES or .env
-  version: 'v1',
-  version_date: '2017-11-07'
+const discovery = new DiscoveryV1({
+  version: '2018-03-05'
 });
 
 // make 'query' a promise function


### PR DESCRIPTION
- upgrade watson-developer-cloud
- allow for iam-apikey values to used for discovery service
- replaced some deprecated discovery APIs
- fixes #121 by allowing URL to be passed to discovery service