### PR TITLE
TEST - DO NOT MERGE!

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Use the ``Deploy to IBM Cloud`` button **OR** create the services and run locall
 
 ## Deploy to IBM Cloud
 
-[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-discovery-ui.git)
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-discovery-ui.git&branch=standard-plan)
  
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy``.
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,15 +2,13 @@
 declared-services:
   wdui-discovery-service:
     label: discovery
-    plan: lite
+    plan: advanced
 applications:
 - path: .
   name: watson-discovery-ui
   buildpack: sdk-for-nodejs
-  memory: 256M
+  memory: 1024M
   instances: 1
   random-route: false
   services:
   - wdui-discovery-service
-env:
-  OPTIMIZE_MEMORY: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/IBM/watson-discovery-ui.git"
   },
   "scripts": {
-    "start": "node --max_old_space_size=256 app.js",
+    "start": "node app.js",
     "start:watch": "nodemon app.js",
     "bootstrap": "cp env.sample .env",
     "test -u": "jest -u",

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ arrayOfFiles.forEach(function(file) {
 // shorten the list if we are loading - trail version of IBM Cloud 
 // is limited to 256MB application size, so use this if you get
 // out of memory errors.
-discoveryDocs = discoveryDocs.slice(0,300);
+//discoveryDocs = discoveryDocs.slice(0,300);
 
 const discovery = new DiscoveryV1({
   version: '2018-04-20'


### PR DESCRIPTION
This is for users who have a non-trial version of an IBM Cloud account. To use, go to the 'standard-plan'' branch README, and select the "Deploy to IBM Cloud" button. This version provides the additional capabilities:
- creates an advanced Watson Discovery service
- allocates more memory for the app
- loads all reviews into discovery