### PR TITLE
Use 'LT' for size instead of '0'

### DIFF
--- a/lib/watson-discovery-setup.js
+++ b/lib/watson-discovery-setup.js
@@ -269,7 +269,7 @@ WatsonDiscoverySetup.prototype.createDiscoveryEnvironment = function(params) {
     const createParams = {
       name: params.environment_name,
       description: 'Discovery environment created by ' + params.default_name,
-      size: '0' // Use string to avoid default of 1.
+      size: 'LT' // Use string to avoid default of 1.
     };
     this.discoveryClient.createEnvironment(createParams, (err, data) => {
       if (err) {
@@ -365,8 +365,8 @@ WatsonDiscoverySetup.prototype.loadDiscoveryCollection = function(params) {
             const doc = docs[i];
             var file = fs.readFileSync(doc);
 
-            this.discoveryClient.addDocument({environment_id: params.environment_id, 
-              collection_id: params.collection_id, file: file, 
+            this.discoveryClient.addDocument({environment_id: params.environment_id,
+              collection_id: params.collection_id, file: file,
               filename: doc}, (err, data) => {
               if (err) {
                 // we got an error on this one doc, but keep loading the rest


### PR DESCRIPTION
Size of '0' is invalid for this plan (the free Lite plan).
Use suggested size of 'LT'.

Closes: #162